### PR TITLE
Fix bug where cucumber commands appear in all text editors, find steps w...

### DIFF
--- a/cucumber.eclipse.editor/plugin.xml
+++ b/cucumber.eclipse.editor/plugin.xml
@@ -70,7 +70,7 @@
       <command
             categoryId="cucumber.eclipse.editor.find"
             description="Find step"
-            id="cucumber.eclipse.editor.formmater.findstep"
+            id="cucumber.eclipse.editor.navigation.findstep"
             name="Find step">
       </command>
    </extension>
@@ -85,7 +85,7 @@
          point="org.eclipse.ui.popupMenus">
      <viewerContribution
         id="cucumber.eclipse.editor.gherkin"
-        targetID="#TextEditorContext">
+        targetID="#CukeEditorContext">
 	    <action id="cucumber.eclipse.edtior.action.format"
 	       label="Pretty Format"
 	       icon="icons/cukes.gif"
@@ -95,15 +95,15 @@
            definitionId="cucumber.eclipse.editor.formmater.pretty_formatter"
 	       >
 	    </action>
-	   	<action id="cucumber.eclipse.editor.action.findstep"
-	       label="Find Step"
-	       icon="icons/cukes.gif"
-	       menubarPath="additions"
-	       helpContextId="cucumber.eclipse.editor.findsteps_action_context"
-	       class="cucumber.eclipse.editor.editors.PopupMenuFindStepActionDelegate"	
-           definitionId="cucumber.eclipse.editor.formmater.findsteps"
-	       >
-	    </action>
+        <action
+              class="cucumber.eclipse.editor.editors.PopupMenuFindStepActionDelegate"
+              definitionId="cucumber.eclipse.editor.navigation.findstep"
+              helpContextId="cucumber.eclipse.editor.findsteps_action_context"
+              icon="icons/cukes.gif"
+              id="cucumber.eclipse.editor.action.findstep"
+              label="Find Step"
+              menubarPath="additions">
+        </action>
 	 </viewerContribution>
    </extension>
    <extension

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
@@ -12,6 +12,17 @@ public class Editor extends TextEditor {
 		setSourceViewerConfiguration(new GherkinConfiguration(colorManager));
 		setDocumentProvider(new GherkinDocumentProvider());
 	}
+	
+	
+	
+	@Override
+	protected void initializeEditor() {
+		super.initializeEditor();
+		setEditorContextMenuId("#CukeEditorContext");
+	}
+
+
+
 	public void dispose() {
 		super.dispose();
 		colorManager.dispose();

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
@@ -5,12 +5,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.text.BadLocationException;
@@ -25,6 +22,7 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.eclipse.ui.texteditor.ITextEditor;
 
 import cucumber.eclipse.steps.integration.IStepDefinitions;
 import cucumber.eclipse.steps.integration.Step;
@@ -34,7 +32,7 @@ import cucumber.eclipse.steps.jdt.StepDefinitions;
 public class PopupMenuFindStepActionDelegate implements IEditorActionDelegate {
 	
 	private IStepDefinitions stepDefinitions = new StepDefinitions();
-	private Editor editorPart;
+	private IEditorPart editorPart;
 	private Pattern cukePattern = Pattern.compile("(?:Given|When|Then|And|But) (.*)$");
 	private Pattern variablePattern = Pattern.compile("<([^>]+)>");
 	
@@ -97,10 +95,13 @@ public class PopupMenuFindStepActionDelegate implements IEditorActionDelegate {
 	
 
 	private String getSelectedLine() {
-		TextSelection selecton = (TextSelection) editorPart.getSelectionProvider().getSelection();
+		
+		ITextEditor editor = (ITextEditor) editorPart;
+				
+		TextSelection selecton = (TextSelection) editor.getSelectionProvider().getSelection();
 		int line = selecton.getStartLine();	
 		
-		IDocumentProvider docProvider = editorPart.getDocumentProvider();
+		IDocumentProvider docProvider = editor.getDocumentProvider();
 		IDocument doc = docProvider.getDocument(editorPart.getEditorInput());
 		try {
 			String stepLine = doc.get(doc.getLineOffset(line), doc.getLineLength(line)).trim();
@@ -116,7 +117,7 @@ public class PopupMenuFindStepActionDelegate implements IEditorActionDelegate {
 
 	@Override
 	public void setActiveEditor(IAction action, IEditorPart targetEditor) {
-		this.editorPart = (Editor) targetEditor;
+		this.editorPart = targetEditor;
 	}
 
 }


### PR DESCRIPTION
...as breaking other text editors so fix that too

Kind of a double fix this one, it fixes my delegate to make it not crash the other text editors as well as moving the Cuke popup commands to the cuke editor only. If this is not desired then probably just merge the one file. Seems a little odd to have cucumber actions on every text editor though.
