### PR TITLE
Use extension point for gathering step implementations

### DIFF
--- a/cucumber.eclipse.editor/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.editor/META-INF/MANIFEST.MF
@@ -18,8 +18,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.5.0",
  org.eclipse.pde.ui;bundle-version="3.5.0",
  org.eclipse.core.resources,
  org.eclipse.ui.workbench,
- cucumber.eclipse.steps.integration,
- cucumber.eclipse.steps.jdt
+ cucumber.eclipse.steps.integration
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .,

--- a/cucumber.eclipse.steps.jdt/build.properties
+++ b/cucumber.eclipse.steps.jdt/build.properties
@@ -1,4 +1,5 @@
 source.. = src/main/java/
 output.. = classes/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.xml

--- a/cucumber.eclipse.steps.jdt/plugin.xml
+++ b/cucumber.eclipse.steps.jdt/plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="cucumber.eclipse.steps.integration">
+      <stepDefinitionIntegration
+            class="cucumber.eclipse.steps.jdt.StepDefinitions">
+      </stepDefinitionIntegration>
+   </extension>
+
+</plugin>


### PR DESCRIPTION
Hi,

I'm working on an Eclipse RCP app that is about to gain support for gherkin files and running them in a specialized environment. Since we won't be using Cucumber-JVM the first thing that caught my eye was the hard dependency onto the jdt-steps plugin which we'd not want to ship.

Since the extension point already existed I simply added the necessary glue code to use that extension point and instantiate the implementations.  I expect that any project will not have more than one language for the step-implementations, so just asking them all for their steps and then matching that should be fine and not cause any false-positives.

Hopefully formatting is correct, unfortunately I didn't find any formatting-settings file that I could just import to get the formatting rules you use. Hence I've used the "Java" builtin formatting from Eclipse which seems to fit the code surrounding my changes.
