### PR TITLE
Remove what looks like debug output

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
@@ -81,7 +81,6 @@ public class PopupMenuFindStepActionDelegate implements IEditorActionDelegate {
 			e.printStackTrace();
 		}
 		
-		System.out.println(steps.toString());
 	}
 	
 	Step matchSteps(Set<Step> steps, String currentLine) {
@@ -100,7 +99,6 @@ public class PopupMenuFindStepActionDelegate implements IEditorActionDelegate {
 				}
 			}
 			
-			System.out.println(cukeStep);
 		} 
 		return null;
 	}


### PR DESCRIPTION
This looks like debug output accidentally comitted when the step-lookup
was implemented. Remove it as it is rather ugly when starting an RCP
application using the editor from a terminal. And if not doing that the
output shows up nowhere anyway.
