### PR TITLE
Make steps.integration plugin a non-ui plugin

### DIFF
--- a/cucumber.eclipse.steps.integration/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.steps.integration/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-Name: Cucumber Steps Integration
 Bundle-SymbolicName: cucumber.eclipse.steps.integration;singleton:=true
 Bundle-Version: 0.0.10.qualifier
 Bundle-Activator: cucumber.eclipse.steps.integration.Activator
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.5.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/Activator.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/Activator.java
@@ -1,12 +1,12 @@
 package cucumber.eclipse.steps.integration;
 
-import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.core.runtime.Plugin;
 import org.osgi.framework.BundleContext;
 
 /**
  * The activator class controls the plug-in life cycle
  */
-public class Activator extends AbstractUIPlugin {
+public class Activator extends Plugin {
 
 	// The plug-in ID
 	public static final String PLUGIN_ID = "cucumber.eclipse.steps.integration"; //$NON-NLS-1$


### PR DESCRIPTION
This makes it possible to use the interface in plugins that have to run in
headless mode and hence have no ui.
