### PR TITLE
Relax the matching of step definitions a bit

### DIFF
--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/Step.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/Step.java
@@ -32,7 +32,7 @@ public class Step {
 	}
 	
 	public boolean matches(String s) {
-		return compiledText.matcher(s).matches();
+		return compiledText.matcher(s).find();
 	}
 	
 	@Override


### PR DESCRIPTION
Using find() avoids the anchoring that matches() does by default, so the
step definition is not required to begin and end exactly at the passed-in
cukeStep This behavior matches at least cucumber/ruby's matching during
the execution where the regular expression is not anchored by default.

In addition this change passes the complete line to the Step instead of
stripping out the keywords. The reason for that is supporting bdd
frameworks where the keyword is included in the expression because the
framework only provides a generic 'Step' annotation instead of dedicated
Given/When/Then/... annotations for marking the step definitions.