### PR TITLE
Pass the actual feature file to the IStepDefinitions instance

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
@@ -8,8 +8,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -61,19 +61,20 @@ public class PopupMenuFindStepActionDelegate implements IEditorActionDelegate {
 	public void run(IAction action) {
 
 		IEditorInput input = editorPart.getEditorInput();
-		
+
 		// Editor contents needs to be associated with an eclipse project
 		// for this to work, if not then simply do nothing.
-		if (!(input instanceof IFileEditorInput)) return;
-		IProject project = ((IFileEditorInput) input).getFile().getProject();
+		if (!(input instanceof IFileEditorInput)) {
+			return;
+		}
+		IFile featurefile = ((IFileEditorInput) input).getFile();
 
 		Set<Step> steps = new HashSet<Step>();
 		for (IStepDefinitions stepDef : getStepDefinitions()) {
-			steps.addAll(stepDef.getSteps(project));
+			steps.addAll(stepDef.getSteps(featurefile));
 		}
 
 		String selectedLine = getSelectedLine();
-		
 		Step matchedStep = matchSteps(steps, selectedLine);
 		try {
 			if (matchedStep != null) openEditor(matchedStep);

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/IStepDefinitions.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/IStepDefinitions.java
@@ -2,9 +2,9 @@ package cucumber.eclipse.steps.integration;
 
 import java.util.Set;
 
-import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IFile;
 
 public interface IStepDefinitions {
 
-	Set<Step> getSteps(IProject project);
+	Set<Step> getSteps(IFile featurefile);
 }

--- a/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/StepDefinitions.java
+++ b/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/StepDefinitions.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -48,9 +49,10 @@ public class StepDefinitions implements IStepDefinitions {
 	private Pattern cukeAnnotationMatcher = Pattern.compile("cucumber\\.api\\.java\\.([a-z_]+)\\.(.*)$");
 	
 	@Override
-	public Set<Step> getSteps(IProject project) {
+	public Set<Step> getSteps(IFile featurefile) {
 		Set<Step> steps = new HashSet<Step>();
 
+		IProject project = featurefile.getProject();
 		try {
 			if (project.isNatureEnabled("org.eclipse.jdt.core.javanature")) {
 				IJavaProject javaProject = JavaCore.create(project);


### PR DESCRIPTION
This can be useful in cases where the lookup of step implementations
wants to consider the directory of the feature file for finding steps
instead of going through a complete project. In particular to avoid reporting
steps that are not usable from a certain feature file due to them being
in unrelated directories.
