### PR TITLE
Added the ability to substitute an Eclipse variable into the feature path

### DIFF
--- a/cucumber.eclipse.editor/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.editor/META-INF/MANIFEST.MF
@@ -17,6 +17,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.5.0",
  org.eclipse.jdt.debug.ui;bundle-version="3.4.0",
  org.eclipse.pde.ui;bundle-version="3.5.0",
  org.eclipse.core.resources,
+ org.eclipse.core.variables,
  org.eclipse.ui.workbench,
  cucumber.eclipse.steps.integration
 Bundle-ActivationPolicy: lazy

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/launching/CucumberFeatureLocalApplicationLaunchConfigurationDelegate.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/launching/CucumberFeatureLocalApplicationLaunchConfigurationDelegate.java
@@ -1,20 +1,15 @@
 package cucumber.eclipse.launching;
 
-import java.awt.List;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.model.ILaunchConfigurationDelegate;
 import org.eclipse.debug.core.model.ILaunchConfigurationDelegate2;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.launching.AbstractJavaLaunchConfigurationDelegate;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMRunner;
@@ -52,7 +47,7 @@ public class CucumberFeatureLocalApplicationLaunchConfigurationDelegate extends 
 		boolean isRerun= false;
 		boolean isUsage= false;
 		
-		featurePath = config.getAttribute(CucumberFeatureLaunchConstants.ATTR_FEATURE_PATH, featurePath);
+		featurePath = substituteVar(config.getAttribute(CucumberFeatureLaunchConstants.ATTR_FEATURE_PATH, featurePath));
 		gluePath  = config.getAttribute(CucumberFeatureLaunchConstants.ATTR_GLUE_PATH, gluePath);
 		isMonochrome = config.getAttribute(CucumberFeatureLaunchConstants.ATTR_IS_MONOCHROME, isMonochrome);
 		isPretty = config.getAttribute(CucumberFeatureLaunchConstants.ATTR_IS_PRETTY,isPretty );
@@ -125,5 +120,20 @@ public class CucumberFeatureLocalApplicationLaunchConfigurationDelegate extends 
 
 	}
 
+	/**
+	 * Substitute any variable
+	 */
+	private static String substituteVar(String s) {
+		if (s == null) {
+			return s;
+		}
+		try {
+			return VariablesPlugin.getDefault().getStringVariableManager()
+					.performStringSubstitution(s);
+		} catch (CoreException e) {
+			System.out.println("Could not substitute variable " + s);
+			return null;
+		}
+	}
 
 }


### PR DESCRIPTION
Added the ability to substitute an Eclipse variable into the feature path name while creating a "Run Configuration". This helps when sharing launch configurations across team members by using a relative path instead of an absolute one. For example:
Feature Path: `${project_loc}/src/tests/features/belly.feature`

I didn't specify a version for the `org.eclipse.core.variables` plugin because I couldn't seem to get anything other than 3.2 to show up as an available dependency. It looks like there is at least a 3.7 version and it's part of core so I'm not too worried, but if you think this is an issue, I can add a [3.5.0) requirement.

`substituteVar` is stolen from: https://github.com/eclipse/m2e-core/blob/86b43f8aabe312f643fa08fd8320a5649a382939/org.eclipse.m2e.launching/src/org/eclipse/m2e/internal/launch/LaunchingUtils.java#L28

Also removed unused imports as a good citizen.
