### PR TITLE
fix "WARNING: Cucumber-JVM's --format option is deprecated. Please use -...

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/launching/CucumberFeatureLocalApplicationLaunchConfigurationDelegate.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/launching/CucumberFeatureLocalApplicationLaunchConfigurationDelegate.java
@@ -71,7 +71,7 @@ public class CucumberFeatureLocalApplicationLaunchConfigurationDelegate extends 
 		
 		
 		String glue = "--glue";
-		String formatter = "--format";
+		String formatter = "--plugin"; // Cucumber-JVM's --format option is deprecated. Please use --plugin instead.
 		Collection<String> args = new ArrayList<String>();
 		//String[] args = new String[6];
 		args.add(featurePath);


### PR DESCRIPTION
Fixes the following warning...

> **WARNING:** Cucumber-JVM's --format option is deprecated. Please use --plugin instead.