### PR TITLE
fix NPE when languageCode is null and just default to EN

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepActionDelegate.java
@@ -169,7 +169,12 @@ public class PopupMenuFindStepActionDelegate extends AbstractHandler {
 	
 	private Pattern getLanguageKeyWordMatcher(String languageCode) {
 		try {
-			I18n i18n = new I18n(languageCode.toLowerCase());
+			if (languageCode == null) {
+				languageCode = "en";
+			} else {
+				languageCode = languageCode.toLowerCase();
+			}
+			I18n i18n = new I18n(languageCode);
 			
 			StringBuilder sb = new StringBuilder();
 			sb.append("(?:");


### PR DESCRIPTION
I wondered why the <kbd>Find Step</kbd> Feature did not worked for me and noticed that it was caused by a `NullPointerException`...