### PR TITLE
syntax coloring for `@tags`

### DIFF
--- a/cucumber.eclipse.editor/plugin.xml
+++ b/cucumber.eclipse.editor/plugin.xml
@@ -52,6 +52,12 @@
         </colorDefinition>
         <colorDefinition 
         	categoryId="cucumber.eclipse.editor.presentation"
+        	id="cucumber.eclipse.editor.presentation.gherkin_tag_colour"
+        	label="Tag Colour"
+        	value="0,128,255">
+        </colorDefinition>
+        <colorDefinition 
+        	categoryId="cucumber.eclipse.editor.presentation"
         	id="cucumber.eclipse.editor.presentation.gherkin_numeric_literal_colour"
         	label="Numeric Colour"
         	value="0,128,0">

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinColors.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinColors.java
@@ -8,6 +8,7 @@ public enum GherkinColors {
 	STRING	("cucumber.eclipse.editor.presentation.gherkin_string_colour"), 
 	NUMERIC	("cucumber.eclipse.editor.presentation.gherkin_numeric_literal_colour"), 
 	STEP	("cucumber.eclipse.editor.presentation.gherkin_step_colour"), 
+	TAG		("cucumber.eclipse.editor.presentation.gherkin_tag_colour"), 
 	DEFAULT	("cucumber.eclipse.editor.presentation.gherkin_text_colour");
 	
 	public final String COLOR_PREFERENCE_ID;

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
@@ -31,6 +31,7 @@ public class GherkinKeywordScanner extends RuleBasedScanner {
 		
 		IToken keyword= new Token(new TextAttribute(manager.getColor(GherkinColors.KEYWORD)));
 		IToken step= new Token(new TextAttribute(manager.getColor(GherkinColors.STEP)));
+		IToken tag= new Token(new TextAttribute(manager.getColor(GherkinColors.TAG)));
 		IToken string= new Token(new TextAttribute(manager.getColor(GherkinColors.STRING)));
 		IToken comment= new Token(new TextAttribute(manager.getColor(GherkinColors.COMMENT)));
 		IToken other= new Token(new TextAttribute(manager.getColor(GherkinColors.DEFAULT)));
@@ -47,6 +48,9 @@ public class GherkinKeywordScanner extends RuleBasedScanner {
 		rules.add(new SingleLineRule("\"", "\"", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
 		rules.add(new SingleLineRule("'", "'", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
 
+		// Add rule for tags.
+		rules.add(new GherkinTagRule(tag));
+		
 		// Add rule for placeholders.
 		rules.add(new GherkinPlaceholderRule(placeholder));
 		

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinTagRule.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinTagRule.java
@@ -1,0 +1,52 @@
+package cucumber.eclipse.editor.editors;
+
+import org.eclipse.jface.text.rules.ICharacterScanner;
+import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.Token;
+
+public class GherkinTagRule implements IRule {
+
+	private IToken token;
+
+	public GherkinTagRule(IToken token) {
+		this.token = token;
+	}
+
+	@Override
+	public IToken evaluate(ICharacterScanner scanner) {
+		int column = scanner.getColumn();
+		if (column >= 1) {
+			scanner.unread();
+			int pc = scanner.read();
+			if (!Character.isWhitespace(pc)) {
+				return Token.UNDEFINED;
+			}
+		}
+		int c = scanner.read();
+		int count = 1;
+		if (c == '@') {
+			while (c != ICharacterScanner.EOF) {
+				if ( (c == '@' && count > 1) // second @-sign, this can not be a vaild tag
+					|| Character.isWhitespace(c)
+					) {
+					// rewind last read character
+					scanner.unread();
+					count--;
+					break;
+				}
+				count++;
+				c = scanner.read();
+			}
+			if (count > 2) {
+				return token;
+			}
+		}
+		// put the scanner back to the original position if no match
+		for (int i = 0; i < count; i++) {
+			scanner.unread();
+		}
+		return Token.UNDEFINED;
+	}
+
+}


### PR DESCRIPTION
added syntax coloring for `@tags` and do not confuse them with email addresses.

see screen grap...
![screen shot 2015-02-15 at 22 08 06](https://cloud.githubusercontent.com/assets/26716/6205014/28d4f30a-b55f-11e4-8b30-b75fb2d1b92d.png)