### PR TITLE
Fix tests failing during build

### DIFF
--- a/cucumber.eclipse.editor.test/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.editor.test/META-INF/MANIFEST.MF
@@ -3,15 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Cucumber Editor Test
 Bundle-SymbolicName: cucumber.eclipse.editor.test
 Bundle-Version: 0.0.11.qualifier
-Bundle-Activator: cucumber.eclipse.editor.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4;bundle-version="4.0.0",
- org.eclipse.ui;bundle-version="3.5.0",
- org.eclipse.core.runtime;bundle-version="3.5.0",
- org.eclipse.ui.editors;bundle-version="3.5.0",
- org.eclipse.jface.text;bundle-version="3.5.0",
- org.eclipse.core.resources;bundle-version="3.5.0",
- cucumber.eclipse.editor;bundle-version="0.0.4",
- cucumber.eclipse.steps.integration
-Import-Package: cucumber.eclipse.editor.editors
+Fragment-Host: cucumber.eclipse.editor
+Require-Bundle: org.junit4;bundle-version="4.0.0"


### PR DESCRIPTION
Made cucumber.eclipse.editor.test a fragment. This is a common way to separate test from production code while still being able to unit test non public classes/methods.