### PR TITLE
Add target definition file

### DIFF
--- a/cucumber.eclipse.targetdefinition/cucumber.eclipse.targetdefinition.target
+++ b/cucumber.eclipse.targetdefinition/cucumber.eclipse.targetdefinition.target
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="targetdefinition" sequenceNumber="8">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="3.5.2.M20100211-1343"/>
+<repository location="http://download.eclipse.org/releases/galileo"/>
+</location>
+</locations>
+</target>

--- a/cucumber.eclipse.targetdefinition/pom.xml
+++ b/cucumber.eclipse.targetdefinition/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>cucumber.eclipse</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.0.11-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>cucumber.eclipse.targetdefinition</artifactId>
+	<packaging>eclipse-target-definition</packaging>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,16 +21,8 @@
 		<module>cucumber.eclipse.steps.integration</module>
 		<module>cucumber.eclipse.steps.jdt</module>
 		<module>cucumber.eclipse.p2updatesite</module>
+		<module>cucumber.eclipse.targetdefinition</module>
 	</modules>
-
-	<repositories>
-		<repository>
-			<id>galileo</id>
-			<url>http://download.eclipse.org/releases/galileo/</url>
-			<layout>p2</layout>
-		</repository>
-
-	</repositories>
 
 	<build>
 		<plugins>
@@ -38,6 +30,15 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<artifact>
+							<groupId>cucumber.eclipse</groupId>
+							<artifactId>cucumber.eclipse.targetdefinition</artifactId>
+							<version>${project.version}</version>
+						</artifact>
+					</target>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
Make it possible for contributors to develop in their Eclipse version of choice. This approach is the only way to share the same target platform configuration between Tycho and Eclipse. (see: https://wiki.eclipse.org/Tycho/Target_Platform)