### PR TITLE
Correct line numbers of error/missing step markers.

### DIFF
--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarkerTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarkerTest.java
@@ -28,6 +28,7 @@ public class GherkinErrorMarkerTest {
                 + "  Scenario: x\n"
                 + "    Given x\n"; // step name at line 3, position 10
         Document document = new Document(source);
+        final AtomicInteger actualLineNumber = new AtomicInteger();
         final AtomicInteger actualCharStart = new AtomicInteger();
         final AtomicInteger actualCharEnd = new AtomicInteger();
         
@@ -37,11 +38,13 @@ public class GherkinErrorMarkerTest {
                     }
                     
                     public void add(String type, IFile file, int severity, String message, int lineNumber, int charStart, int charEnd) {
+                    	actualLineNumber.set(lineNumber);
                         actualCharStart.set(charStart);
                         actualCharEnd.set(charEnd);
                     }
                 }, new TestFile(), document)).parse(source, "", 0);
         
+        assertThat("lineNumber", actualLineNumber.get(), is(4)); // marker line numbers are 1-based
         assertThat("charStart", actualCharStart.get(), is(document.getLineOffset(3) + 10));
         assertThat("charEnd", actualCharEnd.get(), is(document.getLineOffset(3) + 11));
     }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarker.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarker.java
@@ -172,7 +172,7 @@ public class GherkinErrorMarker implements Formatter {
 					file,
 					IMarker.SEVERITY_ERROR,
 					buf.toString(),
-					line - 1,
+					line,
 					document.getLineOffset(line - 1),
 					document.getLineOffset(line - 1) + document.getLineLength(line - 1));
 		} catch (BadLocationException e) {
@@ -201,7 +201,7 @@ public class GherkinErrorMarker implements Formatter {
 				featureFile,
 				IMarker.SEVERITY_WARNING,
 				"Step does not have a matching glue code.",
-				stepLine.getLine() - 1,
+				stepLine.getLine(),
 				region.getOffset(),
 				region.getOffset() + region.getLength());
 	}


### PR DESCRIPTION
Syntax error and step missing markers are currently being created with a line number attribute one lower than expected (i.e. a marker on line 1 shows "line 0" in the location column of the Problems or Markers views).

This PR resolves this issue.