### PR TITLE
Set editor tab width to 2 to bring in line with formatter.

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinConfiguration.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinConfiguration.java
@@ -66,4 +66,8 @@ public class GherkinConfiguration extends TextSourceViewerConfiguration {
 		return reconciler;
 	}
 
+	@Override
+	public int getTabWidth(ISourceViewer sourceViewer) {
+		return 2;
+	}
 }


### PR DESCRIPTION
The Gherkin editor formatter (Ctrl+Shift+F in editor) formats tabs to have a width of 2, but a tab key in the editor inserts a tab of the default width.

This PR sets the editor tab width to 2 to bring it in line with the formatter.