### PR TITLE
Outline view

### DIFF
--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/GherkinModelTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/GherkinModelTest.java
@@ -77,4 +77,48 @@ public class GherkinModelTest {
         assertThat("offset", range.getOffset(), is(document.getLineOffset(5)));
         assertThat("range", range.getLength(), is(document.getLineOffset(8) - document.getLineOffset(5)));
     }
+    
+    @Test
+    public void featureElementHasAttachedChildren() throws BadLocationException {        
+        String source = "Feature: x\n"
+                + "\n"
+                + "  Background:\n"
+                + "    When x\n"
+                + "\n"
+                + "  Scenario Outline: 1\n"
+                + "    Given y\n"
+                + "\n"
+                + "    Examples:\n"
+                + "      | a | b |\n"
+                + "      | 1 | 2 |\n"
+                + "\n"
+                + "  Scenario: 2\n"
+                + "    Given z\n";
+        Document document = new Document(source);
+        GherkinModel model = new GherkinModel();
+        
+        model.updateFromDocument(document);
+        PositionedElement feature = model.getFeatureElement();
+        
+        assertThat("feature.children.size",
+                feature.getChildren().size(), is(3));
+        assertThat("feature.children[0].background",
+                feature.getChildren().get(0).isBackground(), is(true));
+        assertThat("feature.children[1].scenarioOutline",
+                feature.getChildren().get(1).isScenarioOutline(), is(true));
+        assertThat("feature.children[2].scenario",
+                feature.getChildren().get(2).isScenario(), is(true));
+        assertThat("feature.children[0].children.size",
+                feature.getChildren().get(0).getChildren().size(), is(1));
+        assertThat("feature.children[0].children[0].step",
+                feature.getChildren().get(0).getChildren().get(0).isStep(), is(true));
+        assertThat("feature.children[1].children.size",
+                feature.getChildren().get(1).getChildren().size(), is(1));
+        assertThat("feature.children[1].children[0].step",
+                feature.getChildren().get(1).getChildren().get(0).isStep(), is(true));
+        assertThat("feature.children[2].children.size",
+                feature.getChildren().get(2).getChildren().size(), is(1));
+        assertThat("feature.children[2].children[0].step",
+                feature.getChildren().get(2).getChildren().get(0).isStep(), is(true));
+    }
 }

--- a/cucumber.eclipse.editor/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.editor/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.5.0",
  org.eclipse.pde.ui;bundle-version="3.5.0",
  org.eclipse.core.resources,
  org.eclipse.core.variables,
+ org.eclipse.ui.views;bundle-version="3.4.0",
  org.eclipse.ui.workbench,
  cucumber.eclipse.steps.integration,
  org.eclipse.text

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
@@ -9,6 +9,9 @@ import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
@@ -18,6 +21,9 @@ import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionSupport;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
@@ -25,6 +31,7 @@ import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.editors.text.TextEditor;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 
+import cucumber.eclipse.editor.Activator;
 import cucumber.eclipse.editor.markers.MarkerManager;
 import cucumber.eclipse.editor.steps.ExtensionRegistryStepProvider;
 
@@ -153,6 +160,24 @@ public class Editor extends TextEditor {
 		if (IContentOutlinePage.class.equals(required)) {
 			if (outlinePage == null) {
 				outlinePage = new GherkinOutlinePage();
+				outlinePage.addSelectionChangedListener(new ISelectionChangedListener() {
+					
+					@Override
+					public void selectionChanged(SelectionChangedEvent event) {
+						PositionedElement firstElement = (PositionedElement) ((IStructuredSelection)
+								event.getSelection()).getFirstElement();
+						
+						if (firstElement != null) {
+							try {
+								selectAndReveal(firstElement.toPosition().getOffset(), 0);
+							} catch (BadLocationException e) {
+								Activator.getDefault().getLog().log(new Status(IStatus.ERROR,
+										Activator.PLUGIN_ID, "Couldn't set editor selection "
+												+ "from outline", e));
+							}
+						}
+					}
+				});
 			}
 			outlinePage.setInput(getEditorInput());
 			return outlinePage;

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinModel.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinModel.java
@@ -23,48 +23,6 @@ import org.eclipse.jface.text.Position;
 
 public class GherkinModel {
 
-	protected static class PositionedElement {
-		private BasicStatement statement;
-		private int endOffset = -1;
-		private IDocument document;
-
-		public PositionedElement(IDocument doc, BasicStatement stmt) {
-			this.statement = stmt;
-			this.document = doc;
-		}
-
-		private static int getDocumentLine(int line) {
-			// numbering in document is 0-based;
-			return line - 1;
-		}
-
-		public void setEndLine(int lineNo) {
-			try {
-				endOffset = document.getLineOffset(getDocumentLine(lineNo))
-						+ document.getLineLength(getDocumentLine(lineNo));
-			} catch (BadLocationException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-		}
-
-		public BasicStatement getStatement() {
-			return statement;
-		}
-
-		public Position toPosition() throws BadLocationException {
-			int offset = document.getLineOffset(getDocumentLine(statement
-					.getLine()));
-			if (endOffset == -1) {
-				endOffset = offset
-						+ document.getLineLength(getDocumentLine(statement
-								.getLine()));
-			}
-
-			return new Position(offset, endOffset - offset);
-		}
-	}
-	
 	private List<PositionedElement> elements = new ArrayList<PositionedElement>();
 	
 	public List<Position> getFoldRanges() {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinOutlinePage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinOutlinePage.java
@@ -1,0 +1,104 @@
+package cucumber.eclipse.editor.editors;
+
+import gherkin.formatter.model.BasicStatement;
+
+import org.eclipse.jface.viewers.BaseLabelProvider;
+import org.eclipse.jface.viewers.IElementComparer;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.views.contentoutline.ContentOutlinePage;
+
+public class GherkinOutlinePage extends ContentOutlinePage {
+
+	private class ContentProvider implements ITreeContentProvider {
+
+		public void dispose() {
+		}
+
+		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+		}
+
+		public Object[] getElements(Object inputElement) {
+			return featureElement == null ? new Object[0]
+					: new Object[] { featureElement };
+		}
+
+		public Object[] getChildren(Object parentElement) {
+			return ((PositionedElement) parentElement).getChildren().toArray();
+		}
+
+		public Object getParent(Object element) {
+			return null;
+		}
+
+		public boolean hasChildren(Object element) {
+			return !((PositionedElement) element).getChildren().isEmpty();
+		}
+	}
+
+	private class LabelProvider extends BaseLabelProvider implements ILabelProvider {
+
+		public Image getImage(Object element) {
+			return null;
+		}
+
+		public String getText(Object element) {
+			return element.toString();
+		}
+	}
+
+	private static class ElementComparer implements IElementComparer {
+		public int hashCode(Object element) {
+			return element instanceof PositionedElement
+					? ((PositionedElement) element).getStatement().getLine()
+							: element.hashCode();
+		}
+	
+		public boolean equals(Object a, Object b) {
+			if (a instanceof PositionedElement && b instanceof PositionedElement) {
+				BasicStatement s1 = ((PositionedElement) a).getStatement();
+				BasicStatement s2 = ((PositionedElement) b).getStatement();
+				
+				return s1.getLine().equals(s2.getLine())
+						&& s1.getKeyword().equals(s2.getKeyword())
+						&& s1.getName().equals(s2.getName());
+			}
+			
+			return a.equals(b);
+		}
+	}
+
+	private PositionedElement featureElement;
+
+	private TreeViewer viewer;
+
+	private IEditorInput input;
+
+	public void createControl(Composite parent) {
+		super.createControl(parent);
+		viewer = getTreeViewer();
+		viewer.setContentProvider(new ContentProvider());
+		viewer.setLabelProvider(new LabelProvider());
+		viewer.setComparer(new ElementComparer());
+		viewer.setInput(input);
+	}
+
+	public void setInput(IEditorInput input) {
+		this.input = input;
+		if (viewer != null) {
+			viewer.setInput(input);
+		}
+	}
+
+	public void update(PositionedElement featureElement) {
+		this.featureElement = featureElement;
+		if (viewer != null) {
+			viewer.refresh();
+		}
+	}
+}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinReconcilingStrategy.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinReconcilingStrategy.java
@@ -46,7 +46,7 @@ public class GherkinReconcilingStrategy implements IReconcilingStrategy,
 		
 		Display.getDefault().asyncExec(new Runnable() {
 			public void run() {
-				editor.updateFoldingStructure(model.getFoldRanges());
+				editor.updateGherkinModel(model);
 			}
 		});
 	}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
@@ -1,0 +1,49 @@
+package cucumber.eclipse.editor.editors;
+
+import gherkin.formatter.model.BasicStatement;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+
+class PositionedElement {
+	private BasicStatement statement;
+	private int endOffset = -1;
+	private IDocument document;
+
+	public PositionedElement(IDocument doc, BasicStatement stmt) {
+		this.statement = stmt;
+		this.document = doc;
+	}
+
+	private static int getDocumentLine(int line) {
+		// numbering in document is 0-based;
+		return line - 1;
+	}
+
+	public void setEndLine(int lineNo) {
+		try {
+			endOffset = document.getLineOffset(getDocumentLine(lineNo))
+					+ document.getLineLength(getDocumentLine(lineNo));
+		} catch (BadLocationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+	public BasicStatement getStatement() {
+		return statement;
+	}
+
+	public Position toPosition() throws BadLocationException {
+		int offset = document.getLineOffset(getDocumentLine(statement
+				.getLine()));
+		if (endOffset == -1) {
+			endOffset = offset
+					+ document.getLineLength(getDocumentLine(statement
+							.getLine()));
+		}
+
+		return new Position(offset, endOffset - offset);
+	}
+}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import gherkin.formatter.model.Background;
 import gherkin.formatter.model.BasicStatement;
+import gherkin.formatter.model.DescribedStatement;
 import gherkin.formatter.model.Examples;
 import gherkin.formatter.model.Feature;
 import gherkin.formatter.model.Scenario;
@@ -92,5 +93,22 @@ class PositionedElement {
 		}
 
 		return new Position(offset, endOffset - offset);
+	}
+	
+	@Override
+	public String toString() {
+		String result;
+		
+		if (statement instanceof DescribedStatement) {
+			result = ((DescribedStatement) statement).getName();
+		}
+		else if (statement instanceof Step) {
+			result = ((Step) statement).getKeyword() + ((Step) statement).getName();
+		}
+		else {
+			result = statement.toString();
+		}
+		
+		return result;
 	}
 }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
@@ -1,6 +1,16 @@
 package cucumber.eclipse.editor.editors;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import gherkin.formatter.model.Background;
 import gherkin.formatter.model.BasicStatement;
+import gherkin.formatter.model.Examples;
+import gherkin.formatter.model.Feature;
+import gherkin.formatter.model.Scenario;
+import gherkin.formatter.model.ScenarioOutline;
+import gherkin.formatter.model.Step;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -10,12 +20,17 @@ class PositionedElement {
 	private BasicStatement statement;
 	private int endOffset = -1;
 	private IDocument document;
+	private List<PositionedElement> children = new ArrayList<PositionedElement>();
 
 	public PositionedElement(IDocument doc, BasicStatement stmt) {
 		this.statement = stmt;
 		this.document = doc;
 	}
 
+	public void addChild(PositionedElement child) {
+		children.add(child);
+	}
+	
 	private static int getDocumentLine(int line) {
 		// numbering in document is 0-based;
 		return line - 1;
@@ -33,6 +48,38 @@ class PositionedElement {
 
 	public BasicStatement getStatement() {
 		return statement;
+	}
+	
+	public List<PositionedElement> getChildren() {
+		return Collections.unmodifiableList(children);
+	}
+
+	public boolean isBackground() {
+		return statement instanceof Background;
+	}
+	
+	public boolean isExamples() {
+		return statement instanceof Examples;
+	}
+
+	public boolean isFeature() {
+		return statement instanceof Feature;
+	}
+
+	public boolean isScenarioOutline() {
+		return statement instanceof ScenarioOutline;
+	}
+
+	public boolean isScenario() {
+		return statement instanceof Scenario;
+	}
+
+	public boolean isStep() {
+		return statement instanceof Step;
+	}
+	
+	public boolean isStepContainer() {
+		return isBackground() || isScenarioOutline() || isScenario();
 	}
 
 	public Position toPosition() throws BadLocationException {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PositionedElement.java
@@ -101,6 +101,9 @@ class PositionedElement {
 		
 		if (statement instanceof DescribedStatement) {
 			result = ((DescribedStatement) statement).getName();
+			if ("".equals(result)) {
+				result = statement.getKeyword();
+			}
 		}
 		else if (statement instanceof Step) {
 			result = ((Step) statement).getKeyword() + ((Step) statement).getName();


### PR DESCRIPTION
This PR adds a (very) simple outline view for the Gherkin editor as described in issue #55.

Scenarios/scenaro outlines and step nodes are added to the content outline tree. Selecting a node will move the caret in the Gherkin editor to the relevant node.