### PR TITLE
Fix marker not found when in CJK language.

### DIFF
--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
@@ -21,6 +21,14 @@ public class StepMatcherTest {
 		
 		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "When I run a test"));
 	}
+	
+	@Test
+	public void otherLanguageStepMatches() {
+	    
+	    Step s = createStep("^执行$");
+	    
+	    assertEquals(s, stepMatcher.matchSteps("zh-CN", Collections.singleton(s), "当执行"));
+	}
 
 	@Test
 	public void scenarioOutlines() {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
@@ -43,21 +43,19 @@ private Pattern getLanguageKeyWordMatcher(String languageCode) {
 	try {
 		if (languageCode == null) {
 			languageCode = "en";
-		} else {
-			languageCode = languageCode.toLowerCase();
 		}
 		I18n i18n = new I18n(languageCode);
-		
+
 		StringBuilder sb = new StringBuilder();
 		sb.append("(?:");
 		String delim = "";
 	
-		for(String keyWord : i18n.getCodeKeywords()) {
-			sb.append(delim).append(keyWord);
+		for(String keyWord : i18n.getStepKeywords()) {
+			sb.append(delim).append(Pattern.quote(keyWord));
 			delim = "|";
 		}
 	
-		return Pattern.compile((sb.append(") (.*)$").toString()));
+		return Pattern.compile((sb.append(")(.*)$").toString()));
 	} catch(NullPointerException e) {
 		e.printStackTrace();
 		return null;


### PR DESCRIPTION
1. There a exception thrown  ```languageCode = languageCode.toLowerCase();```,because I18n use exactly case. eg: ```zh-CN,zh-TW```.

2. Line 60 ```return Pattern.compile((sb.append(") (.*)$").toString()));``` append a extra space will cause step match failure in CJK language. So use getStepKeywords and quote it.

3. Add a extra test case ,and it passed.