### PR TITLE
Better Gherkins autocompletion

### DIFF
--- a/cucumber.eclipse.editor/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cucumber Editor
 Bundle-SymbolicName: cucumber.eclipse.editor;singleton:=true
-Bundle-Version: 0.0.11.qualifier
+Bundle-Version: 0.0.13.qualifier
 Bundle-Activator: cucumber.eclipse.editor.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="3.5.0",
  org.eclipse.core.runtime;bundle-version="3.5.0",

--- a/cucumber.eclipse.editor/pom.xml
+++ b/cucumber.eclipse.editor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>cucumber.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.0.11-SNAPSHOT</version>
+		<version>0.0.13-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cucumber.eclipse.editor</artifactId>

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordsAssistProcessor.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordsAssistProcessor.java
@@ -53,6 +53,7 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 			IRegion line = viewer.getDocument().getLineInformationOfOffset(offset);
 			// To trim white-space from the start of typed string
 			String typed = viewer.getDocument().get(line.getOffset(), offset - line.getOffset()).replaceAll(contentAssist.STARTSWITH_ANYSPACE, "");
+			int lineEnd = line.getOffset() + line.getLength();
 			//System.out.println("USER-TYPED =" + typed);
 
 			// Create an ArrayList instance for collecting the generated
@@ -89,7 +90,7 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 				if (typed.matches(contentAssist.KEYWORD_SPACE_WORD_REGEX)) 
 				{
 					//System.out.println("IF-2:Inside ...");
-					String lastPrefix = contentAssist.lastPrefix(typed);
+					String lastPrefix = contentAssist.removeFirstWord(typed);
 					//System.out.println("LAST-PREFIX =" +lastPrefix);
 
 					//Collect all steps with 
@@ -120,7 +121,7 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 							if(step.startsWith(lastPrefix))
 							{	
 								//Populate all matched steps
-								contentAssist.importStepProposals(lastPrefix, offset, ICON, step, result);							
+								contentAssist.importStepProposals(lastPrefix, offset, lineEnd, ICON, step, result);
 							}
 						}
 					}
@@ -145,7 +146,7 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 						{							
 							//System.out.println("stepDetailList ###########");
 							//Populate all step proposal
-							contentAssist.importStepProposals(lastPrefix, offset, ICON, step, result);
+							contentAssist.importStepProposals(lastPrefix, offset, offset, ICON, step, result);
 						}
 					}
 					

--- a/cucumber.eclipse.steps.jdt/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.steps.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cucumber Steps via Eclipse JDT
 Bundle-SymbolicName: cucumber.eclipse.steps.jdt;singleton:=true
-Bundle-Version: 0.0.11.qualifier
+Bundle-Version: 0.0.13.qualifier
 Bundle-Activator: cucumber.eclipse.steps.jdt.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/cucumber.eclipse.steps.jdt/pom.xml
+++ b/cucumber.eclipse.steps.jdt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>cucumber.eclipse</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.0.11-SNAPSHOT</version>
+		<version>0.0.13-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cucumber.eclipse.steps.jdt</artifactId>


### PR DESCRIPTION
## Here are a few use cases that are fixed by this pull request

*note:* the "|" (pipe character) in the description describe where the cursor is in the editor at the moment I press `Ctrl+Space.`

* **`Given I|`** auto-completes to `Given I want to write a step with precondition`
   * It's **correct**

* **`Given I want|`** shows **No Step Definition Found**
 * *The issue:* I want to auto-complete to **Given I want to write a step with precondition**

* **`Given I want |`** auto-completes to `Given I want I want to write a step with precondition`
 * *The issue:* this sentence has no meaning and does not exist.
I want to auto-complete to "Given I want to write a step with precondition"

* **`Given I| made a slight mistake by not knowing the sentence exactly`** auto-completes to `Given I want to write a step with preconditionmade a slight mistake by not knowing the sentence exactly`
 * *The issue:* one Gerkins line can only contain one sentence, so the remaining of the line is of no use.
I want to auto-complete to `Given I want to write a step with precondition`

* **`When On the product page, |`** shows **No Step Definition Found**
 * *The issue:* cannot auto-complete after a comma.
I want to auto-complete to `When On the product page, I click BUY`

* **`Then This|`** shows **This product is shown: "(["]*)"**
 * *The issue:* when accepting the proposal, anything after the colon is removed. 
I get `Then This product is shown`

* **`Then The|`** auto-completes to `The "(["]*)" product is shown (\d+) times`
 * *The issue:* Anti-slashes-and-doucle-quotes have been removed, so it's hard to recognize the regular expression, and its really technical. 
To be more user-friendly, I'd replace most common expressions with {text} and {number}. 
My pull request auto-completes to `The "{text}" product is shown {integer-number} times` (and `(\d+\.\d+)` would be displayed `{real-number}`, for prices, for instance)