### PR TITLE
Fixed issue with steps from dependency projects incorrectly marked as not having matching code

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarker.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarker.java
@@ -201,7 +201,7 @@ public class GherkinErrorMarker implements Formatter {
 		markerManager.add(MarkerIds.UNMATCHED_STEP,
 				featureFile,
 				IMarker.SEVERITY_WARNING,
-				"Step does not have a matching glue code.",
+				"Step '" + stepLine.getName() + "' does not have a matching glue code",
 				stepLine.getLine(),
 				region.getOffset(),
 				region.getOffset() + region.getLength());


### PR DESCRIPTION
Current implementation of plugin looks for steps only in the same project in which feature is located. But sometimes step definitions could be located in projects added as dependencies to current one. So, there is a search for step definitions in these projects as well added in this PR.

Also minor improvement for 'Step does not have a matching glue code' warning message is added. It will be useful to have also step name in it "Step 'step name' does not have a matching glue code"