### PR TITLE
Fix for step matching in scenario outlines

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepFormatter.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/PopupMenuFindStepFormatter.java
@@ -1,0 +1,100 @@
+package cucumber.eclipse.editor.editors;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import gherkin.formatter.Formatter;
+import gherkin.formatter.model.Background;
+import gherkin.formatter.model.Examples;
+import gherkin.formatter.model.ExamplesTableRow;
+import gherkin.formatter.model.Feature;
+import gherkin.formatter.model.Scenario;
+import gherkin.formatter.model.ScenarioOutline;
+import gherkin.formatter.model.Step;
+
+public class PopupMenuFindStepFormatter implements Formatter {
+
+	private List<String> resolvedStepNames = new ArrayList<String>();
+
+	private int stepLineNumber;
+
+	public PopupMenuFindStepFormatter(int stepLineNumber) {
+		this.stepLineNumber = stepLineNumber;
+	}
+
+	@Override
+	public void background(Background background) { }
+
+	@Override
+	public void close() { }
+
+	@Override
+	public void done() { }
+
+	@Override
+	public void eof() { }
+
+	@Override
+	public void examples(Examples examples) {
+		if (resolvedStepNames.isEmpty()) {
+			return;
+		}
+		ExamplesTableRow examplesHeader = examples.getRows().get(0);
+		for (int i = 1; i < examples.getRows().size(); i++) {
+			ExamplesTableRow exampleLine = examples.getRows().get(i);
+			String resolvedStep = getResolvedStepForExample(examplesHeader, exampleLine);
+			if (!resolvedStepNames.contains(resolvedStep)) {
+				resolvedStepNames.add(resolvedStep);
+			}
+		}
+	}
+
+	@Override
+	public void feature(Feature feature) { }
+
+	@Override
+	public void scenario(Scenario scenario) { }
+
+	@Override
+	public void scenarioOutline(ScenarioOutline scenarioOutline) { }
+
+	@Override
+	public void step(Step step) {
+		String stepString = step.getKeyword() + step.getName();
+		if (stepLineNumber == step.getLine()) {
+			resolvedStepNames.add(stepString);
+		}
+	}
+
+	@Override
+	public void syntaxError(String state, String event, List<String> legalEvents, String uri, Integer line) { }
+
+	@Override
+	public void uri(String uri) { }
+	
+	private Map<String, String> getExampleVariablesMap(ExamplesTableRow header, ExamplesTableRow values) {
+		Map<String, String> result = new LinkedHashMap<String, String>();
+		for (int i = 0; i < header.getCells().size(); i++) {
+			result.put(header.getCells().get(i), values.getCells().get(i));
+		}
+		return result;
+	}
+
+	private String getResolvedStepForExample(ExamplesTableRow examplesHeader, ExamplesTableRow exampleLine) {
+		Map<String, String> variables = getExampleVariablesMap(examplesHeader, exampleLine);
+		String stepString = resolvedStepNames.get(0);
+		if (variables != null) {
+			for (Map.Entry<String, String> variable : variables.entrySet()) {
+				stepString = stepString.replace("<" + variable.getKey() + ">", variable.getValue());
+			}
+		}
+		return stepString;
+		
+	}
+
+	public List<String> getResolvedStepNames() {
+		return resolvedStepNames;
+	}
+}


### PR DESCRIPTION
1. Added new Gherkin formatter for FindStep popup menu handler, which takes step name for selected line and in case step belongs to scenario outline - scans all examples and generates different step string with replaced variables for each example. FindStep popup menu handler now looks for step definition for any example string (with replaced variables)
2. Same logic implemented for error marker: now if steps belong to scenario outline, formatter goes over all examples, replaces all variables and adds warning for each example, in which step with replaced variables does not match any step definition.

Issue https://github.com/cucumber/cucumber-eclipse/issues/159 should be fixed now