### PR TITLE
Fix for parameter match to alias list

### DIFF
--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
@@ -13,49 +13,82 @@ import cucumber.eclipse.steps.integration.Step;
 public class StepMatcherTest {
 
 	private StepMatcher stepMatcher = new StepMatcher();
-	
+
 	@Test
 	public void simpleStepMatches() {
-		
+
 		Step s = createStep("^I run a test$");
-		
+
 		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "When I run a test"));
 	}
-	
+
 	@Test
 	public void otherLanguageStepMatches() {
-	    
-	    Step s = createStep("^执行$");
-	    
-	    assertEquals(s, stepMatcher.matchSteps("zh-CN", Collections.singleton(s), "当执行"));
+
+		Step s = createStep("^执行$");
+
+		assertEquals(s, stepMatcher.matchSteps("zh-CN", Collections.singleton(s), "当执行"));
 	}
 
 	@Test
 	public void scenarioOutlines() {
-		
+
 		Step s = createStep("^there are (\\d)* cucumbers$");
-		
+
 		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are <start> cucumbers"));
 	}
-	
+
 	@Test
 	public void scenarioOutlinesString() {
-		
+
 		Step s = createStep("^there are (\\w)* cucumbers$");
 		Step s2 = createStep("^I should see the (.*) message$");
 		Set<Step> steps = new HashSet<Step>();
 		steps.add(s2);
 		steps.add(s);
-		
+
 		assertEquals(s, stepMatcher.matchSteps("en", steps, "Given there are <start> cucumbers"));
 	}
-	
+
+	@Test
+	public void scenarioOutlinesAlias() {
+
+		Step s = createStep("^there are (two|ten) cucumbers$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are <cukes> cucumbers"));
+	}
+
+	@Test
+	public void scenarioAlias() {
+
+		Step s = createStep("^there are (two|ten) cucumbers$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are two cucumbers"));
+	}
+
+	@Test
+	public void scenarioOutlinesAliasMultiple() {
+
+		Step s = createStep("^there are (two|ten) cucumbers and (five|fifteen) gherkins$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s),
+				"Given there are <cukes> cucumbers and <gherks> gherkins"));
+	}
+
+	@Test
+	public void scenarioAliasMultiple() {
+
+		Step s = createStep("^there are (two|ten) cucumbers and (five|fifteen) gherkins$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s),
+				"Given there are two cucumbers and fifteen gherkins"));
+	}
+
 	private Step createStep(String text) {
-		
+
 		Step s = new Step();
 		s.setText(text);
 		return s;
 	}
-	
-}
 
+}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
@@ -1,16 +1,16 @@
 package cucumber.eclipse.editor.editors;
 
-import gherkin.I18n;
-
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import cucumber.eclipse.steps.integration.Step;
+import gherkin.I18n;
 
-class StepMatcher{
+class StepMatcher {
 	private Pattern variablePattern = Pattern.compile("<([^>]+)>");
+	private Pattern aliasPattern = Pattern.compile("\\(([\\w|/]+)\\)");
 
 	Step matchSteps(String languageCode, Set<Step> steps, String currentLine) {
 		Pattern cukePattern = getLanguageKeyWordMatcher(languageCode);
@@ -30,6 +30,14 @@ class StepMatcher{
 			cukeStep = variableMatcher.replaceAll("0");
 
 			for (Step step : steps) {
+				// for each alias match, want to insert 0 as an option
+				// e.g. (two|ten) becomes (0|two|ten)
+				Matcher aliasMatcher = aliasPattern.matcher(step.getText());
+				while (aliasMatcher.find()) {
+					step.setText(
+							step.getText().replace(aliasMatcher.group(0), "(0|" + aliasMatcher.group(0).substring(1)));
+				}
+
 				if (step.matches(cukeStep)) {
 					return step;
 				}
@@ -37,31 +45,31 @@ class StepMatcher{
 
 		}
 		return null;
-}
-
-private Pattern getLanguageKeyWordMatcher(String languageCode) {
-	try {
-		if (languageCode == null) {
-			languageCode = "en";
-		}
-		I18n i18n = new I18n(languageCode);
-
-		StringBuilder sb = new StringBuilder();
-		sb.append("(?:");
-		String delim = "";
-	
-		for(String keyWord : i18n.getStepKeywords()) {
-			sb.append(delim).append(Pattern.quote(keyWord));
-			delim = "|";
-		}
-	
-		return Pattern.compile((sb.append(")(.*)$").toString()));
-	} catch(NullPointerException e) {
-		e.printStackTrace();
-		return null;
-	} catch(PatternSyntaxException e) {
-		e.printStackTrace();
-		return null;
 	}
-}
+
+	private Pattern getLanguageKeyWordMatcher(String languageCode) {
+		try {
+			if (languageCode == null) {
+				languageCode = "en";
+			}
+			I18n i18n = new I18n(languageCode);
+
+			StringBuilder sb = new StringBuilder();
+			sb.append("(?:");
+			String delim = "";
+
+			for (String keyWord : i18n.getStepKeywords()) {
+				sb.append(delim).append(Pattern.quote(keyWord));
+				delim = "|";
+			}
+
+			return Pattern.compile((sb.append(")(.*)$").toString()));
+		} catch (NullPointerException e) {
+			e.printStackTrace();
+			return null;
+		} catch (PatternSyntaxException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
This change fixes an edge case.
When an outline step uses a \<parameter\>, and the step is using alias choices (e.g. (one|two|three), then the \<parameter\> is replaced with 0 but this won't match the aliases and we see an unmatched step warning in the code.
As documented under //fixme - one approach is to read the scenario examples and substitute the values of the first example set. This would be very hard work.
However I came up with a quick-win solution - to append '0' as a valid choice on the alias list on the step.
e.g. when step-matching, a step regexp such as (one|two|three) is transformed to (0|one|two|three) - this allows step matching in both important cases:
1) the feature file uses one of the selections directly (and hence is not parameterised and cannot be determined, located or transformed), e.g. I eat three cucumbers (where 'three' matches the aliases)
2) where the feature file uses a \<parameter\> in a scenario outline.
It works by the existing code substituting \<parameter\> into 0 - but the change prefixes (0| onto the alias list in the step to enable matching.
4 unit test cases were added to demonstrate.

Awesome work on this plugin, by far the best consistent formatter and step navigator which is why I use this and wanted to contribute.