### PR TITLE
Generic outline <parameter> matching to any cucumber regexp

### DIFF
--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
@@ -13,49 +13,82 @@ import cucumber.eclipse.steps.integration.Step;
 public class StepMatcherTest {
 
 	private StepMatcher stepMatcher = new StepMatcher();
-	
+
 	@Test
 	public void simpleStepMatches() {
-		
+
 		Step s = createStep("^I run a test$");
-		
+
 		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "When I run a test"));
 	}
-	
+
 	@Test
 	public void otherLanguageStepMatches() {
-	    
-	    Step s = createStep("^执行$");
-	    
-	    assertEquals(s, stepMatcher.matchSteps("zh-CN", Collections.singleton(s), "当执行"));
+
+		Step s = createStep("^执行$");
+
+		assertEquals(s, stepMatcher.matchSteps("zh-CN", Collections.singleton(s), "当执行"));
 	}
 
 	@Test
 	public void scenarioOutlines() {
-		
+
 		Step s = createStep("^there are (\\d)* cucumbers$");
-		
+
 		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are <start> cucumbers"));
 	}
-	
+
 	@Test
 	public void scenarioOutlinesString() {
-		
+
 		Step s = createStep("^there are (\\w)* cucumbers$");
 		Step s2 = createStep("^I should see the (.*) message$");
 		Set<Step> steps = new HashSet<Step>();
 		steps.add(s2);
 		steps.add(s);
-		
+
 		assertEquals(s, stepMatcher.matchSteps("en", steps, "Given there are <start> cucumbers"));
 	}
-	
+
+	@Test
+	public void scenarioOutlinesAlias() {
+
+		Step s = createStep("^there are (two|ten) cucumbers$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are <cukes> cucumbers"));
+	}
+
+	@Test
+	public void scenarioAlias() {
+
+		Step s = createStep("^there are (two|ten) cucumbers$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are two cucumbers"));
+	}
+
+	@Test
+	public void scenarioOutlinesAliasMultiple() {
+
+		Step s = createStep("^there are (two|ten) cucumbers and (five|fifteen) gherkins$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s),
+				"Given there are <cukes> cucumbers and <gherks> gherkins"));
+	}
+
+	@Test
+	public void scenarioAliasMultiple() {
+
+		Step s = createStep("^there are (two|ten) cucumbers and (five|fifteen) gherkins$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s),
+				"Given there are two cucumbers and fifteen gherkins"));
+	}
+
 	private Step createStep(String text) {
-		
+
 		Step s = new Step();
 		s.setText(text);
 		return s;
 	}
-	
-}
 
+}

--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepMatcherTest.java
@@ -84,6 +84,40 @@ public class StepMatcherTest {
 				"Given there are two cucumbers and fifteen gherkins"));
 	}
 
+	@Test
+	public void scenarioOutlinesAliasNonMatching() {
+
+		Step s = createStep("^there are (?:two|ten) cucumbers$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are <cukes> cucumbers"));
+	}
+
+	@Test
+	public void scenarioAliasNonMatching() {
+
+		Step s = createStep("^there are (?:two|ten) cucumbers$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s), "Given there are two cucumbers"));
+	}
+
+	@Test
+	public void scenarioOutlinesAliasNonMatchingMultiple() {
+
+		Step s = createStep("^there are (?:two|ten) cucumbers and (?:five|fifteen) gherkins$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s),
+				"Given there are <cukes> cucumbers and <gherks> gherkins"));
+	}
+
+	@Test
+	public void scenarioAliasNonMatchingMultiple() {
+
+		Step s = createStep("^there are (?:two|ten) cucumbers and (?:five|fifteen) gherkins$");
+
+		assertEquals(s, stepMatcher.matchSteps("en", Collections.singleton(s),
+				"Given there are two cucumbers and fifteen gherkins"));
+	}
+
 	private Step createStep(String text) {
 
 		Step s = new Step();

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
@@ -11,6 +11,7 @@ import gherkin.I18n;
 class StepMatcher {
 	private Pattern variablePattern = Pattern.compile("<([^>]+)>");
 	private Pattern aliasPattern = Pattern.compile("\\(([\\w|/]+)\\)");
+	private Pattern groupPattern = Pattern.compile("(\\(.+?\\))");
 
 	Step matchSteps(String languageCode, Set<Step> steps, String currentLine) {
 		Pattern cukePattern = getLanguageKeyWordMatcher(languageCode);
@@ -22,20 +23,22 @@ class StepMatcher {
 		if (matcher.matches()) {
 			String cukeStep = matcher.group(1);
 
-			// FIXME: Replace variables with 0 for now to allow them to
+			// FIXME: Replace variables with <p> for now to allow them to
 			// match steps
 			// Should really read the whole scenario outline and sub in the
 			// first scenario
 			Matcher variableMatcher = variablePattern.matcher(cukeStep);
-			cukeStep = variableMatcher.replaceAll("0");
+			cukeStep = variableMatcher.replaceAll("<p>");
 
 			for (Step step : steps) {
-				// for each alias match, want to insert 0 as an option
-				// e.g. (two|ten) becomes (0|two|ten)
-				Matcher aliasMatcher = aliasPattern.matcher(step.getText());
-				while (aliasMatcher.find()) {
+				// for each group match, want to insert <p> as an option
+				// e.g. (\\d+) becomes (<p>|\\d+)
+				// e.g. (two|ten) becomes (<p>|two|ten)
+				Matcher groupMatcher = groupPattern.matcher(step.getText());
+				while (groupMatcher.find()) {
 					step.setText(
-							step.getText().replace(aliasMatcher.group(0), "(0|" + aliasMatcher.group(0).substring(1)));
+							step.getText().replace(groupMatcher.group(0),
+									"(<p>|" + groupMatcher.group(0).substring(1)));
 				}
 
 				if (step.matches(cukeStep)) {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/StepMatcher.java
@@ -1,16 +1,16 @@
 package cucumber.eclipse.editor.editors;
 
-import gherkin.I18n;
-
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import cucumber.eclipse.steps.integration.Step;
+import gherkin.I18n;
 
-class StepMatcher{
+class StepMatcher {
 	private Pattern variablePattern = Pattern.compile("<([^>]+)>");
+	private Pattern aliasPattern = Pattern.compile("\\(([\\w|/]+)\\)");
 
 	Step matchSteps(String languageCode, Set<Step> steps, String currentLine) {
 		Pattern cukePattern = getLanguageKeyWordMatcher(languageCode);
@@ -30,6 +30,14 @@ class StepMatcher{
 			cukeStep = variableMatcher.replaceAll("0");
 
 			for (Step step : steps) {
+				// for each alias match, want to insert 0 as an option
+				// e.g. (two|ten) becomes (0|two|ten)
+				Matcher aliasMatcher = aliasPattern.matcher(step.getText());
+				while (aliasMatcher.find()) {
+					step.setText(
+							step.getText().replace(aliasMatcher.group(0), "(0|" + aliasMatcher.group(0).substring(1)));
+				}
+
 				if (step.matches(cukeStep)) {
 					return step;
 				}
@@ -37,31 +45,31 @@ class StepMatcher{
 
 		}
 		return null;
-}
-
-private Pattern getLanguageKeyWordMatcher(String languageCode) {
-	try {
-		if (languageCode == null) {
-			languageCode = "en";
-		}
-		I18n i18n = new I18n(languageCode);
-
-		StringBuilder sb = new StringBuilder();
-		sb.append("(?:");
-		String delim = "";
-	
-		for(String keyWord : i18n.getStepKeywords()) {
-			sb.append(delim).append(Pattern.quote(keyWord));
-			delim = "|";
-		}
-	
-		return Pattern.compile((sb.append(")(.*)$").toString()));
-	} catch(NullPointerException e) {
-		e.printStackTrace();
-		return null;
-	} catch(PatternSyntaxException e) {
-		e.printStackTrace();
-		return null;
 	}
-}
+
+	private Pattern getLanguageKeyWordMatcher(String languageCode) {
+		try {
+			if (languageCode == null) {
+				languageCode = "en";
+			}
+			I18n i18n = new I18n(languageCode);
+
+			StringBuilder sb = new StringBuilder();
+			sb.append("(?:");
+			String delim = "";
+
+			for (String keyWord : i18n.getStepKeywords()) {
+				sb.append(delim).append(Pattern.quote(keyWord));
+				delim = "|";
+			}
+
+			return Pattern.compile((sb.append(")(.*)$").toString()));
+		} catch (NullPointerException e) {
+			e.printStackTrace();
+			return null;
+		} catch (PatternSyntaxException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
I found a more generic way of matching outline parameters.
The current code replaces any \<parameter\> in a step with 0, hoping for the cucumber step regular expressions to match. It is already noted in the code that this is a temporary fix - the ideal solution is to read the outline examples and substitute the first parameter values in order to make a tested step match. However this is unreasonable work.
The inverse solution to this, is to modify the cucumber regexp dynamically during matching to become lenient to \<parameter\> matching. Hence, all \<parameter\> are replaced with generic \<p\> on the gherkin step, and on the regexp all matching groups e.g. (\d+), (.\*), (one|two) have an additional \<p\>| inserted.
i.e
(\d+) -> (\<p\>|\d+)
(.\*) -> (\<p\>|.\*)
(one|two) -> (\<p\>|one|two)

This seems to resolve my issues and other users' issues with regard to parameter matching.
Pls review, and comment.
I've added several unit tests to prove the cases.

Apologies for the whitespace formatting noise, I'm not sure what formatting you are using on this code.