### PR TITLE
Update GherkinKeywordScanner.java

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
@@ -12,10 +12,15 @@ import org.eclipse.jface.text.*;
 
 public class GherkinKeywordScanner extends RuleBasedScanner {
 		
+    // TODO 1: Change to retrieve a list of Keywords from the .json file, depending on selected i18n language
     private static final List<String> FEATURE_ELEMENT_KEYWORD_KEYS = Arrays.asList("scenario_outline","feature", "background", "scenario", "examples");
     private static final List<String> STEP_KEYWORD_KEYS = Arrays.asList("given", "when", "then", "and", "but");
+    
     private static I18n i18n;   
+    
+    // TODO 2: Change to retrieve language from parsed .feature file, 
     private static String _code = "en";
+    
     private ColorManager manager;
 	
 	public GherkinKeywordScanner(ColorManager manager) {


### PR DESCRIPTION
Syntax Highlight isn't working for languages != en
(I at least tried with file in #language: es to no luck; localized versions of Keywords aren't highlighted in Editor).

Change the way KeyWordScanner creates its list of FEATURE_ELEMENT_KEYWORD_KEYS and STEP_KEYWORD_KEYS so it's based on an i18n _code that is read dynamically from the .feature file open in editor.
