### PR TITLE
Introduce plugin preference to turn off Step matching

### DIFF
--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarkerTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarkerTest.java
@@ -10,50 +10,78 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.junit.Test;
 
+import cucumber.eclipse.editor.Activator;
 import cucumber.eclipse.editor.markers.IMarkerManager;
+import cucumber.eclipse.editor.preferences.ICucumberPreferenceConstants;
 import cucumber.eclipse.editor.steps.IStepProvider;
 import cucumber.eclipse.editor.tests.TestFile;
 import cucumber.eclipse.steps.integration.Step;
 
 public class GherkinErrorMarkerTest {
 
-    @Test
-    public void stepMarksOnlyUnmatchedStep() throws BadLocationException {
-        String source = "Feature: x\n"
-                + "\n"
-                + "  Scenario: x\n"
-                + "    Given x\n"; // step name at line 3, position 10
-        Document document = new Document(source);
-        final AtomicInteger actualLineNumber = new AtomicInteger();
-        final AtomicInteger actualCharStart = new AtomicInteger();
-        final AtomicInteger actualCharEnd = new AtomicInteger();
-        
-        new Parser(new GherkinErrorMarker(newStepProvider(),
-                new IMarkerManager() {
-                    public void removeAll(String type, IFile file) {
-                    }
-                    
-                    public void add(String type, IFile file, int severity, String message, int lineNumber, int charStart, int charEnd) {
-                    	actualLineNumber.set(lineNumber);
-                        actualCharStart.set(charStart);
-                        actualCharEnd.set(charEnd);
-                    }
-                }, new TestFile(), document)).parse(source, "", 0);
-        
-        assertThat("lineNumber", actualLineNumber.get(), is(4)); // marker line numbers are 1-based
-        assertThat("charStart", actualCharStart.get(), is(document.getLineOffset(3) + 10));
-        assertThat("charEnd", actualCharEnd.get(), is(document.getLineOffset(3) + 11));
-    }
+	@Test
+	public void stepMarksOnlyUnmatchedStep() throws BadLocationException {
+		String source = "Feature: x\n"
+				+ "\n"
+				+ "  Scenario: x\n"
+				+ "    Given x\n"; // step name at line 3, position 10
+		Document document = new Document(source);
+		final AtomicInteger actualLineNumber = new AtomicInteger();
+		final AtomicInteger actualCharStart = new AtomicInteger();
+		final AtomicInteger actualCharEnd = new AtomicInteger();
 
-    private IStepProvider newStepProvider() {
-        return new IStepProvider() {
-            public Set<Step> getStepsInEncompassingProject(IFile featurefile) {
-                return emptySet();
-            }
-        };
-    }
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		store.setValue(ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS, true);
+
+		new Parser(new GherkinErrorMarker(newStepProvider(),
+				new IMarkerManager() {
+					public void removeAll(String type, IFile file) {
+					}
+
+					public void add(String type, IFile file, int severity, String message, int lineNumber, int charStart, int charEnd) {
+						actualLineNumber.set(lineNumber);
+						actualCharStart.set(charStart);
+						actualCharEnd.set(charEnd);
+					}
+				}, new TestFile(), document)).parse(source, "", 0);
+
+		assertThat("lineNumber", actualLineNumber.get(), is(4)); // marker line numbers are 1-based
+		assertThat("charStart", actualCharStart.get(), is(document.getLineOffset(3) + 10));
+		assertThat("charEnd", actualCharEnd.get(), is(document.getLineOffset(3) + 11));
+	}
+
+	@Test
+	public void stepMarksNothingWhenOff() throws BadLocationException {
+		String source = "Feature: x\n"
+				+ "\n"
+				+ "  Scenario: x\n"
+				+ "    Given x\n";
+		Document document = new Document(source);
+
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		store.setValue(ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS, false);
+
+		new Parser(new GherkinErrorMarker(newStepProvider(),
+				new IMarkerManager() {
+					public void removeAll(String type, IFile file) {
+					}
+
+					public void add(String type, IFile file, int severity, String message, int lineNumber, int charStart, int charEnd) {
+						assertThat("lookedForStep", false, is(true));
+					}
+				}, new TestFile(), document)).parse(source, "", 0);
+	}
+
+	private IStepProvider newStepProvider() {
+		return new IStepProvider() {
+			public Set<Step> getStepsInEncompassingProject(IFile featurefile) {
+				return emptySet();
+			}
+		};
+	}
 }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinConfiguration.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinConfiguration.java
@@ -1,5 +1,6 @@
 package cucumber.eclipse.editor.editors;
 
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
@@ -14,6 +15,9 @@ import org.eclipse.jface.text.rules.DefaultDamagerRepairer;
 import org.eclipse.jface.text.rules.Token;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.ui.editors.text.TextSourceViewerConfiguration;
+
+import cucumber.eclipse.editor.Activator;
+import cucumber.eclipse.editor.preferences.ICucumberPreferenceConstants;
 
 public class GherkinConfiguration extends TextSourceViewerConfiguration {
 
@@ -52,21 +56,26 @@ public class GherkinConfiguration extends TextSourceViewerConfiguration {
 
 	@Override
 	public IContentAssistant getContentAssistant(ISourceViewer sourceViewer) {
-        ContentAssistant ca = new ContentAssistant();
-        IContentAssistProcessor cap = new GherkinKeywordsAssistProcessor();
-        	ca.setContentAssistProcessor(cap, IDocument.DEFAULT_CONTENT_TYPE);
-        	ca.setInformationControlCreator(getInformationControlCreator(sourceViewer));
-        	
-        	//Added By Girija For Content Assistance
-        	ca.setStatusMessage("<Step>:<Class>, Press 'Ctrl+SPace' For Cucumber Assistance");
-        	ca.setStatusLineVisible(true);
-        	
-        	ca.enableAutoActivation(true);
-        	ca.setAutoActivationDelay(500);
-        	//ca.setProposalPopupOrientation(IContentAssistant.PROPOSAL_OVERLAY);
-        	//ca.setContextInformationPopupOrientation(IContentAssistant.CONTEXT_INFO_ABOVE);
-        	
-        return ca;
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+
+		if (store.getBoolean(ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS)) {
+			ContentAssistant ca = new ContentAssistant();
+			IContentAssistProcessor cap = new GherkinKeywordsAssistProcessor();
+				ca.setContentAssistProcessor(cap, IDocument.DEFAULT_CONTENT_TYPE);
+				ca.setInformationControlCreator(getInformationControlCreator(sourceViewer));
+				
+				//Added By Girija For Content Assistance
+				ca.setStatusMessage("<Step>:<Class>, Press 'Ctrl+SPace' For Cucumber Assistance");
+				ca.setStatusLineVisible(true);
+				
+				ca.enableAutoActivation(true);
+				ca.setAutoActivationDelay(500);
+				//ca.setProposalPopupOrientation(IContentAssistant.PROPOSAL_OVERLAY);
+				//ca.setContextInformationPopupOrientation(IContentAssistant.CONTEXT_INFO_ABOVE);
+				
+			return ca;
+		}
+		return null;
 	}
 	
 	

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarker.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinErrorMarker.java
@@ -11,13 +11,16 @@ import java.util.Set;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.FindReplaceDocumentAdapter;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 
+import cucumber.eclipse.editor.Activator;
 import cucumber.eclipse.editor.markers.IMarkerManager;
 import cucumber.eclipse.editor.markers.MarkerIds;
+import cucumber.eclipse.editor.preferences.ICucumberPreferenceConstants;
 import cucumber.eclipse.editor.steps.IStepProvider;
 import gherkin.formatter.Formatter;
 import gherkin.formatter.model.Background;
@@ -227,16 +230,20 @@ public class GherkinErrorMarker implements Formatter {
 	}
 	
 	public void validateStep(Step stepLine, Map<String, String> examplesLineMap, int currentLine) {
-		String stepString = getResolvedStepStringForExample(stepLine, examplesLineMap);
-		cucumber.eclipse.steps.integration.Step step = new StepMatcher().matchSteps(getDocumentLanguage(document),
-				foundSteps, stepString);
-		if (step == null) {
-			try {
-				markUnmatchedStep(file, document, stepLine, inScenarioOutline ? currentLine : -1);
-			} catch (CoreException e) {
-				e.printStackTrace();
-			} catch (BadLocationException e) {
-				e.printStackTrace();
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+
+		if (store.getBoolean(ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS)) {
+			String stepString = getResolvedStepStringForExample(stepLine, examplesLineMap);
+			cucumber.eclipse.steps.integration.Step step = new StepMatcher().matchSteps(getDocumentLanguage(document),
+																						foundSteps, stepString);
+			if (step == null) {
+				try {
+					markUnmatchedStep(file, document, stepLine, inScenarioOutline ? currentLine : -1);
+				} catch (CoreException e) {
+					e.printStackTrace();
+				} catch (BadLocationException e) {
+					e.printStackTrace();
+				}
 			}
 		}
 	}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferenceInitializer.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferenceInitializer.java
@@ -10,10 +10,11 @@ public class CucumberPreferenceInitializer extends
 
 	@Override
 	public void initializeDefaultPreferences() {
-        IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-        store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES, true);
-        store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS, false);
-        store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_CENTER_STEPS, false);
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+		store.setDefault(ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS, true);
+		store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES, true);
+		store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS, false);
+		store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_CENTER_STEPS, false);
 	}
 
 }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferencePage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferencePage.java
@@ -17,31 +17,39 @@ import cucumber.eclipse.editor.Activator;
 
 public class CucumberPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 
-    public CucumberPreferencePage() {
+	public CucumberPreferencePage() {
 		super(FLAT);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
 	}
-    
+	
 	@Override
 	protected void createFieldEditors() {
 
 		Composite parent = getFieldEditorParent();
 
 		CLabel label = new CLabel(parent, SWT.NULL);
+		label.setText(getString("Plugin Settings"));
+		label.setImage(getImage("icons/cukes.gif"));
+
+		addField(new BooleanFieldEditor(
+			ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS,
+			getString("&Match Steps with Java Step code"), parent));
+
+		label = new CLabel(parent, SWT.NULL);
 		label.setText(getString("Gherkin Formatting"));
 		label.setImage(getImage("icons/cukes.gif"));
 		
-        addField(new BooleanFieldEditor(
-           ICucumberPreferenceConstants.PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES,
-           getString("&Right-align numeric values in tables"), parent));
-        
-        addField(new BooleanFieldEditor(
-           ICucumberPreferenceConstants.PREF_FORMAT_CENTER_STEPS,
-           getString("&Center Steps"), parent));
+		addField(new BooleanFieldEditor(
+			ICucumberPreferenceConstants.PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES,
+			getString("&Right-align numeric values in tables"), parent));
+		
+		addField(new BooleanFieldEditor(
+			ICucumberPreferenceConstants.PREF_FORMAT_CENTER_STEPS,
+			getString("&Center Steps"), parent));
 
-        addField(new BooleanFieldEditor(
-           ICucumberPreferenceConstants.PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS,
-           getString("&Preserve blank lines between steps"), parent));
+		addField(new BooleanFieldEditor(
+			ICucumberPreferenceConstants.PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS,
+			getString("&Preserve blank lines between steps"), parent));
 
 	}
 

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/ICucumberPreferenceConstants.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/ICucumberPreferenceConstants.java
@@ -4,14 +4,15 @@ import cucumber.eclipse.editor.Activator;
 
 public interface ICucumberPreferenceConstants {
 
-    public static final String _PREFIX = Activator.PLUGIN_ID + "."; //$NON-NLS-1$
+	public static final String _PREFIX = Activator.PLUGIN_ID + "."; //$NON-NLS-1$
 
-    // Preference constants
-    public static final String PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES =
-    		_PREFIX + "format_right_align_numeric_values_in_tables"; //$NON-NLS-1$
-    public static final String PREF_FORMAT_CENTER_STEPS =
-    		_PREFIX + "format_center_steps"; //$NON-NLS-1$
-    public static final String PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS =
-    		_PREFIX + "format_preserve_blank_line_between_steps"; //$NON-NLS-1$
-
+	// Preference constants
+	public static final String PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES =
+			_PREFIX + "format_right_align_numeric_values_in_tables"; //$NON-NLS-1$
+	public static final String PREF_FORMAT_CENTER_STEPS =
+			_PREFIX + "format_center_steps"; //$NON-NLS-1$
+	public static final String PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS =
+			_PREFIX + "format_preserve_blank_line_between_steps"; //$NON-NLS-1$
+	public static final String PREF_CHECK_STEP_DEFINITIONS =
+			_PREFIX + "check_step_definitions"; //$NON-NLS-1$
 }


### PR DESCRIPTION
Please bear with me as I have not worked with Eclipse plugins before... or Java at all for a few years.

This pull request introduces a preference to turn off Step matching and content assist. Useful for people who want the good stuff for .feature file editing, but work with other languages for implemented steps such as Python.

I couldn't determine whether the standard in this project is tabs or spaces. I found mostly tabs when browsing the source code so I went for that.

Comments?