### PR TITLE
Adjusted the NewStepDefFileWizard to generate with quotes for annotations

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/wizard/NewStepDefFileWizard.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/wizard/NewStepDefFileWizard.java
@@ -41,8 +41,8 @@ public class NewStepDefFileWizard extends Wizard implements INewWizard {
 	private static final String CUCUMBER_PACKAGE = "import cucumber.api.java.en.";
 	
 	private static final String ANNOTATION_START = "  @" ;
-	private static final String ANNOTATION_CONTENT_START = "(^you are in ";
-	private static final String ANNOTATION_CONTENT_END = " annotation$)";
+	private static final String ANNOTATION_CONTENT_START = "(\"^you are in ";
+	private static final String ANNOTATION_CONTENT_END = " annotation$\")";
 	
 	private static final String METHOD_START = "  public void ";
 	private static final String METHOD_SIGNATURE = "() ";


### PR DESCRIPTION
Attempting to fix problem where quotes are not generated for step definitions when the new step definition file wizard is used and example definitions generated using check boxes.