### PR TITLE
Feature/fix windows directory format step def

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/wizard/NewStepDefFileWizardPage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/wizard/NewStepDefFileWizardPage.java
@@ -214,13 +214,24 @@ public class NewStepDefFileWizardPage extends WizardPage {
 					return;
 				}
 			}
-			if (!(sourceText.endsWith("/src/main/java") 
-					|| sourceText.endsWith("/src/test/java")) )
-			{
-				//System.out.println("ProjectTextPath:" +sourceText);
-				updateStatus("Source Folder Must Contain '/src/main/java' or '/src/test/java'");		
-				return;
-			}	
+			if(System.getProperty("os.name").toLowerCase().contains("windows")){
+				if (!(sourceText.endsWith("\\src\\main\\java") 
+						|| sourceText.endsWith("\\src\\test\\java")) )
+				{
+					//System.out.println("ProjectTextPath:" +sourceText);
+					updateStatus("Source Folder Must Contain '\\src\\main\\java' or '\\src\\test\\java'");		
+					return;
+				}	
+			}else{
+				if (!(sourceText.endsWith("/src/main/java") 
+						|| sourceText.endsWith("/src/test/java")) )
+				{
+					//System.out.println("ProjectTextPath:" +sourceText);
+					updateStatus("Source Folder Must Contain '/src/main/java' or '/src/test/java'");		
+					return;
+				}	
+			}
+			
 		}catch(Exception ex){
 			updateStatus("Source Folder is not a Java project.");		
 			return;


### PR DESCRIPTION
Fixes a problem where windows users had to switch their backslashes for forwardslashes in order to pass a validation check.

If anyone has any feedback on whether we should be doing an explicit requirement shift for the platform, or use some other solution, I can adjust this pull request to match the conclusion.