### PR TITLE
Fix#192, #196 - NewStepDefFileWizard Source Folder path issue

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/util/Utils.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/util/Utils.java
@@ -125,12 +125,12 @@ public class Utils {
 	    IResource resource = result.getResource();
 	    if (resource != null)
 	    {
-	      result.sourceFolder = resource.getFullPath().removeLastSegments(1).toOSString();
+	      result.sourceFolder = resource.getFullPath().removeLastSegments(1).toString();
 	     // System.out.println("result.sourceFolder-1=" +result.sourceFolder);
 	     
 	      for (IClasspathEntry entry : getSourceFolders(result.getProject()))
 	      {
-	        String source = entry.getPath().toOSString();
+	        String source = entry.getPath().toString();
 	        
 	        System.out.println("Source =" +source);
 	        

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/wizard/NewStepDefFileWizardPage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/wizard/NewStepDefFileWizardPage.java
@@ -214,22 +214,12 @@ public class NewStepDefFileWizardPage extends WizardPage {
 					return;
 				}
 			}
-			if(System.getProperty("os.name").toLowerCase().contains("windows")){
-				if (!(sourceText.endsWith("\\src\\main\\java") 
-						|| sourceText.endsWith("\\src\\test\\java")) )
-				{
-					//System.out.println("ProjectTextPath:" +sourceText);
-					updateStatus("Source Folder Must Contain '\\src\\main\\java' or '\\src\\test\\java'");		
-					return;
-				}	
-			}else{
-				if (!(sourceText.endsWith("/src/main/java") 
-						|| sourceText.endsWith("/src/test/java")) )
-				{
-					//System.out.println("ProjectTextPath:" +sourceText);
-					updateStatus("Source Folder Must Contain '/src/main/java' or '/src/test/java'");		
-					return;
-				}	
+			if (!(sourceText.endsWith("/src/main/java") 
+					|| sourceText.endsWith("/src/test/java")) )
+			{
+				//System.out.println("ProjectTextPath:" +sourceText);
+				updateStatus("Source Folder Must Contain '/src/main/java' or '/src/test/java'");		
+				return;
 			}
 			
 		}catch(Exception ex){


### PR DESCRIPTION
Eclipse by default uses forward slashes in both windows and linux machine in the new file creation wizards and does not use windows file path. In #192 a validation check was added for windows such that backward slashes would not throw validation error. However, this introduced bug #196. This is because eclipse works with forward slashes only and the issue was with the way the generated file path in NewStepDefFileWizard was made to be os specific.
To fix this, I removed the validation check which checks for windows and in the section where the file path is generated, I used toString() instead of toOSString(). This change will fix both issues - #192 and #196.

Let me know if this is ok. I have tested it on my local windows and linux installations.