### PR TITLE
Only match step implementation in same package as feature file

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferenceInitializer.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferenceInitializer.java
@@ -5,8 +5,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import cucumber.eclipse.editor.Activator;
 
-public class CucumberPreferenceInitializer extends
-AbstractPreferenceInitializer {
+public class CucumberPreferenceInitializer extends AbstractPreferenceInitializer {
 
 	@Override
 	public void initializeDefaultPreferences() {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferenceInitializer.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferenceInitializer.java
@@ -6,7 +6,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import cucumber.eclipse.editor.Activator;
 
 public class CucumberPreferenceInitializer extends
-		AbstractPreferenceInitializer {
+AbstractPreferenceInitializer {
 
 	@Override
 	public void initializeDefaultPreferences() {
@@ -15,6 +15,7 @@ public class CucumberPreferenceInitializer extends
 		store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES, true);
 		store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS, false);
 		store.setDefault(ICucumberPreferenceConstants.PREF_FORMAT_CENTER_STEPS, false);
+		store.setDefault(ICucumberPreferenceConstants.PREF_ONLY_SEARCH_PACKAGE, false);
 	}
 
 }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferencePage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberPreferencePage.java
@@ -21,7 +21,7 @@ public class CucumberPreferencePage extends FieldEditorPreferencePage implements
 		super(FLAT);
 		setPreferenceStore(Activator.getDefault().getPreferenceStore());
 	}
-	
+
 	@Override
 	protected void createFieldEditors() {
 
@@ -32,24 +32,28 @@ public class CucumberPreferencePage extends FieldEditorPreferencePage implements
 		label.setImage(getImage("icons/cukes.gif"));
 
 		addField(new BooleanFieldEditor(
-			ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS,
-			getString("&Match Steps with Java Step code"), parent));
+				ICucumberPreferenceConstants.PREF_CHECK_STEP_DEFINITIONS,
+				getString("&Match Steps with Java Step code"), parent));
+
+		addField(new BooleanFieldEditor(
+				ICucumberPreferenceConstants.PREF_ONLY_SEARCH_PACKAGE,
+				getString("&Only match steps from package and sub-packages"), parent));
 
 		label = new CLabel(parent, SWT.NULL);
 		label.setText(getString("Gherkin Formatting"));
 		label.setImage(getImage("icons/cukes.gif"));
-		
-		addField(new BooleanFieldEditor(
-			ICucumberPreferenceConstants.PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES,
-			getString("&Right-align numeric values in tables"), parent));
-		
-		addField(new BooleanFieldEditor(
-			ICucumberPreferenceConstants.PREF_FORMAT_CENTER_STEPS,
-			getString("&Center Steps"), parent));
 
 		addField(new BooleanFieldEditor(
-			ICucumberPreferenceConstants.PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS,
-			getString("&Preserve blank lines between steps"), parent));
+				ICucumberPreferenceConstants.PREF_FORMAT_RIGHT_ALIGN_NUMERIC_VALUES_IN_TABLES,
+				getString("&Right-align numeric values in tables"), parent));
+
+		addField(new BooleanFieldEditor(
+				ICucumberPreferenceConstants.PREF_FORMAT_CENTER_STEPS,
+				getString("&Center Steps"), parent));
+
+		addField(new BooleanFieldEditor(
+				ICucumberPreferenceConstants.PREF_FORMAT_PRESERVE_BLANK_LINE_BETWEEN_STEPS,
+				getString("&Preserve blank lines between steps"), parent));
 
 	}
 

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberUserSettingsPage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/CucumberUserSettingsPage.java
@@ -136,14 +136,15 @@ public class CucumberUserSettingsPage extends PreferencePage
 		return image;
 	}
 
-	
-	
 	// Get Package Name
 	public String getPackageName() {
 		IPreferenceStore store = getPreferenceStore();
-		String myPackage = store.getString(ICucumberPreferenceConstants.PREF_ADD_PACKAGE);
-		//System.out.println("My Package = " + myPackage);
-		return myPackage;		
+		return store.getString(ICucumberPreferenceConstants.PREF_ADD_PACKAGE);
+	}
+
+	public Boolean getOnlyPackages() {
+		IPreferenceStore store = getPreferenceStore();
+		return store.getBoolean(ICucumberPreferenceConstants.PREF_ONLY_SEARCH_PACKAGE);
 	}
 	
 	public static String getString(String key) {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/ICucumberPreferenceConstants.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/preferences/ICucumberPreferenceConstants.java
@@ -15,8 +15,10 @@ public interface ICucumberPreferenceConstants {
 			_PREFIX + "format_preserve_blank_line_between_steps"; //$NON-NLS-1$
 	public static final String PREF_CHECK_STEP_DEFINITIONS =
 			_PREFIX + "check_step_definitions"; //$NON-NLS-1$
-	
+	public static final String PREF_ONLY_SEARCH_PACKAGE =
+			_PREFIX + "only_search_package"; //$NON-NLS-1$
+
 	// Newly Declared By Girija for User-Settings Cucumber Preference Page
 	public static final String PREF_ADD_PACKAGE =
-    		_PREFIX + "add_package"; //$NON-NLS-1$
+			_PREFIX + "add_package"; //$NON-NLS-1$
 }


### PR DESCRIPTION
Added a preference to limit the search scope for step implementation to the package (and the sub-package) for the location of the feature file.

Consider the following setup:
```
\- src/test/java
 \- cucumber/
  \- test/
   \- a/
    |  +- a.feature
    |  +- TestARunner.java
    |  \- TestASteps.java
    \- b/
        +- b.feature
        +- TestBRunner.java
        \- TestBSteps.java
```

By default, `cucumber-eclipse` will match steps in `a.feature` with implementations in `TestBSteps.java` (and vice versa).

With this new preference, steps in `a.feature` will only be matched against implementations in `cucumber.test.a` (and it's sub-packages, if it had any).