### PR TITLE
Changes in step implementation is reflected in feature file

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/jdt/JDTStepDefinitions.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/jdt/JDTStepDefinitions.java
@@ -141,12 +141,12 @@ public class JDTStepDefinitions extends StepDefinitions implements IStepDefiniti
 	
 	@Override
 	public void addStepListener(IStepListener listener) {
-		this.listeners.add(listener);
+		StepDefinitions.listeners.add(listener);
 	}
 
 	@Override
 	public void removeStepListener(IStepListener listener) {
-		this.listeners.remove(listener);
+		StepDefinitions.listeners.remove(listener);
 	}
 
 	public void notifyListeners(StepsChangedEvent event) {

--- a/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/StepDefinitions.java
+++ b/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/StepDefinitions.java
@@ -62,7 +62,7 @@ public class StepDefinitions extends MethodDefinition {
 	private List<MethodDefinition> methodDefList = null;
 	private List<MethodDeclaration> methodDeclList = null;
 
-	public List<IStepListener> listeners = new ArrayList<IStepListener>();
+	protected static List<IStepListener> listeners = new ArrayList<IStepListener>();
 
 	public StepDefinitions() {
 


### PR DESCRIPTION
This fixes the problem that changes in step implementations isn't
reflected in the feature file. Before one had to close/open the feature
file for it to be updated, either when adding or removing matching step
implementations.