### PR TITLE
Don't use hardcoded keywords to support other languages

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/contentassist/CucumberContentAssist.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/contentassist/CucumberContentAssist.java
@@ -40,10 +40,10 @@ public class CucumberContentAssist {
 	// RegEx1 : (Line starts with only a <Step-keyword>[without <space> or
 	// <word>]) OR
 	// (Line doesn't starts with a <Step-keyword>)
-	public final String KEYWORD_REGEX = "(^Given|When|Then|And|But|$[\\S\\W\\D])|(^(?!Given|When|Then|And|But).+)";
+//	public final String KEYWORD_REGEX = "(^Given|When|Then|And|But|$[\\S\\W\\D])|(^(?!Given|When|Then|And|But).+)";
 
 	// RegEx2 : Line starts with <Step-Keyword>+<space>+<any-word>
-	public final String KEYWORD_SPACE_WORD_REGEX = "^(Given|When|Then|And|But)[\\s][\\w\\d\\s\\S]*";
+//	public final String KEYWORD_SPACE_WORD_REGEX = "^(Given|When|Then|And|But)[\\s][\\w\\d\\s\\S]*";
 
 	// RegEx-3 : starts with space
 	public final String STARTSWITH_ANYSPACE = "^\\s+";
@@ -61,7 +61,7 @@ public class CucumberContentAssist {
 	public final String STARTS_ANY = "^[\\w\\d\\S][^\\,]*";
 
 	// Regex-8 : Word starts with any Word/Digit/NonWord/Space
-	public final String KEYWORD_SPACE_REGEX = "^(Given|When|Then|And|But)\\s+";
+//	public final String KEYWORD_SPACE_REGEX = "^(Given|When|Then|And|But)\\s+";
 
 	// Regex-9 : Any Word/Digit/NonWord/Space
 	public final String ANY = "[\\w\\d\\S][\\,]*";
@@ -91,12 +91,8 @@ public class CucumberContentAssist {
 	CompletionProposal matchedStepsProposal = null;
 	private Set<Step> importedSteps = null;
 
-	// For I18n language
-	private String lang = null;
-
 	// Initialize
 	public CucumberContentAssist(String lang, IStepProvider stepProvider) {
-		this.lang = lang;
 		this.importedSteps = stepProvider.getStepsInEncompassingProject();
 
 		// System.out.println("CucumberContentAssist:importedSteps:"
@@ -107,8 +103,8 @@ public class CucumberContentAssist {
 		this.matchedStepList = new ArrayList<String>();
 	}
 
-	public List<String> getStepKeyWords() {
-		List<String> stepKeywords = new I18n(lang).getStepKeywords();
+	public List<String> getStepKeyWords(I18n i18n) {
+		List<String> stepKeywords = i18n.getStepKeywords();
 		stepKeywords.removeAll(asList(junkWords));
 		return stepKeywords;
 	}
@@ -306,8 +302,17 @@ public class CucumberContentAssist {
 	}
 
 	// Get Last word of a String by replacing KEYWORD
-	public String lastPrefix(String string) {
-		String lastStep = string.replaceFirst(KEYWORD_SPACE_REGEX, "");
+	public String lastPrefix(String string, List<String> keywords) {
+		String longestMatch = null;
+		for (String keyword : keywords) {
+			if (string.startsWith(keyword)) {
+				if (longestMatch == null || keyword.length()>longestMatch.length()) {
+					longestMatch = keyword;
+				}
+			}
+		}
+		//replace the keyword
+		String lastStep = longestMatch!=null?string.substring(longestMatch.length()):string;
 		if (lastStep.contains(","))
 			lastStep = lastStep.substring(lastStep.lastIndexOf(",") + 1).trim();
 		return lastStep;

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordsAssistProcessor.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordsAssistProcessor.java
@@ -56,7 +56,7 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 
 			//Initialize CucumberContentAssist
 			this.contentAssist = new CucumberContentAssist(lang, editor.getStepProvider());
-			
+			List<String> stepKeyWords = contentAssist.getStepKeyWords(i18n);
 			// line of cursor locate,and from begin to cursor.
 			IRegion line = viewer.getDocument().getLineInformationOfOffset(offset);
 			
@@ -66,7 +66,7 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 
 			// Capture any Existing Step
 			String preStep = viewer.getDocument().get(line.getOffset(), line.getLength()).replaceAll(contentAssist.STARTSWITH_ANYSPACE, "");
-			preStep = this.contentAssist.lastPrefix(preStep);
+			preStep = this.contentAssist.lastPrefix(preStep,stepKeyWords);
 			//System.out.println("PRE-STEP =" + preStep);
 			
 			// Create an ArrayList instance for collecting the generated
@@ -85,105 +85,20 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 			//To display proposals for any char/string is typed
 			if (typed.length() > 0) 
 			{
-				//1. To Check Typed=<Keyword> OR Typed=AnyWord
-				//POPULATE KEYWORD ASSISTANCE
-				if (typed.matches(contentAssist.KEYWORD_REGEX)) 
-				{
-					  // Don't Delete : Used For Debug
-					 //System.out.println("IF-1:Inside ...");
-					// To display only Step-Keywords
-					for (String string : contentAssist.getStepKeyWords()) {
-						CompletionProposal p = new CompletionProposal(string, offset - typed.length(), typed.length(),string.length(), ICON, null, null, null);
-						result.add(p);
-					}
-				}
-
-				//2.To Check Typed = <Keyword any-words>
-				//POPULATE STEP ASSISTANCE
-				if (typed.matches(contentAssist.KEYWORD_SPACE_WORD_REGEX)) 
-				{
-					//System.out.println("IF-2:Inside ...");
 				
-					String lastPrefix = contentAssist.lastPrefix(typed);
-					//System.out.println("LAST-PREFIX = " +lastPrefix);
+				for (String stepKeyWord : stepKeyWords) {
 					
-					//Collect all steps with 
-					contentAssist.collectAllSteps(lastPrefix);
-					
-					// Collect all steps and matched steps from step-definition file
-					List<String> stepDetailList = contentAssist.importAllStepList();
-					List<String> matchedStepList = contentAssist.importMatchedStepList();
-					
-					 // Don't Delete : Used For Debug
-					//System.out.println("stepDetailList = " +stepDetailList);
-					//System.out.println("matchedStepList = " +matchedStepList);					
-					
-					//1. NO-Proposal For Any Empty List
-					if( matchedStepList.isEmpty() &&
-							stepDetailList.isEmpty())
-					{
-						 // Don't Delete : Used For Debug
-						//System.out.println("NO PROPOSAL-1***************");
-						contentAssist.displayNoProposal(offset, ICON, result);
+					//1. Check if typed is the prefix of any stepword (ignoring trailing space)
+					if (stepKeyWord.trim().startsWith(typed)) {
+						addStepWordCompletionProposal(offset, typed, result, stepKeyWord);
 					}
 					
-					//2. Proposal For Non-Empty Matched-Step-List
-					else if(!matchedStepList.isEmpty())
-					{
-						 // Don't Delete : Used For Debug
-						//System.out.println("matchedStepList NOT EMPTY......");
-						for(String step : matchedStepList)
-						{							
-							//For starts-with Step proposal 
-							if(step.startsWith(lastPrefix))
-							{	
-								//Populate all matched starts-with steps
-								contentAssist.importStepProposals(lastPrefix, preStep, offset, ICON, step, result);							
-							}
-							
-							//For contains Step proposal
-							else if(step.contains(lastPrefix))
-							{							 
-								//Populate all matched contains steps
-								contentAssist.importStepProposals(lastPrefix, preStep, offset, ICON, step, result);							
-							}
-						}
-					}
-					
-					//3. No proposal for Empty Matched-Step-List
-					else if( lastPrefix.matches(contentAssist.STARTS_ANY) && 
-							 matchedStepList.isEmpty() )
-					{
-						 // Don't Delete : Used For Debug
-						//System.out.println("NO PROPOSAL-2***************");
-						contentAssist.displayNoProposal(offset, ICON, result);
-					}
-					
-					//4. All Step-Proposals if any <space> and COMMA
-					else if(lastPrefix.matches(contentAssist.COMMA_SPACE_REGEX) |
-							!stepDetailList.isEmpty())
-					{
-						 // Don't Delete : Used For Debug
-						//System.out.println("stepDetailList NOT EMPTY......");
-						for(String step : stepDetailList)
-						{	
-							 // Don't Delete : Used For Debug
-							//System.out.println("stepDetailList ###########");
-							//Populate all step proposal
-							contentAssist.importStepProposals(lastPrefix, preStep, offset, ICON, step, result);
-						}
-					}
-			
-					//5. No Match No Proposal
-					else
-					{
-						 // Don't Delete : Used For Debug
-						//System.out.println("NO PROPOSAL-3***************");
-						contentAssist.displayNoProposal(offset, ICON, result);
+					//2.To Check Typed = <Keyword any-words>
+					else if (typed.startsWith(stepKeyWord)){
+						addStepDetailsProposal(offset, typed, preStep, result, stepKeyWords);
 					}
 				}
 			}
-		
 			//New Line starts with blank
 			else 
 			{
@@ -201,6 +116,95 @@ public class GherkinKeywordsAssistProcessor implements IContentAssistProcessor {
 			// ... log the exception ...
 			return NO_COMPLETIONS;
 		}
+	}
+
+	private void addStepDetailsProposal(int offset, String typed, String preStep,
+			ArrayList<ICompletionProposal> result, List<String> stepKeyWords) {
+		//System.out.println("IF-2:Inside ...");
+
+		String lastPrefix = contentAssist.lastPrefix(typed,stepKeyWords);
+		//System.out.println("LAST-PREFIX = " +lastPrefix);
+		
+		//Collect all steps with 
+		contentAssist.collectAllSteps(lastPrefix);
+		
+		// Collect all steps and matched steps from step-definition file
+		List<String> stepDetailList = contentAssist.importAllStepList();
+		List<String> matchedStepList = contentAssist.importMatchedStepList();
+		
+		 // Don't Delete : Used For Debug
+		//System.out.println("stepDetailList = " +stepDetailList);
+		//System.out.println("matchedStepList = " +matchedStepList);					
+		
+		//1. NO-Proposal For Any Empty List
+		if( matchedStepList.isEmpty() &&
+				stepDetailList.isEmpty())
+		{
+			 // Don't Delete : Used For Debug
+			//System.out.println("NO PROPOSAL-1***************");
+			contentAssist.displayNoProposal(offset, ICON, result);
+		}
+		
+		//2. Proposal For Non-Empty Matched-Step-List
+		else if(!matchedStepList.isEmpty())
+		{
+			 // Don't Delete : Used For Debug
+			//System.out.println("matchedStepList NOT EMPTY......");
+			for(String step : matchedStepList)
+			{							
+				//For starts-with Step proposal 
+				if(step.startsWith(lastPrefix))
+				{	
+					//Populate all matched starts-with steps
+					contentAssist.importStepProposals(lastPrefix, preStep, offset, ICON, step, result);							
+				}
+				
+				//For contains Step proposal
+				else if(step.contains(lastPrefix))
+				{							 
+					//Populate all matched contains steps
+					contentAssist.importStepProposals(lastPrefix, preStep, offset, ICON, step, result);							
+				}
+			}
+		}
+		
+		//3. No proposal for Empty Matched-Step-List
+		else if( lastPrefix.matches(contentAssist.STARTS_ANY) && 
+				 matchedStepList.isEmpty() )
+		{
+			 // Don't Delete : Used For Debug
+			//System.out.println("NO PROPOSAL-2***************");
+			contentAssist.displayNoProposal(offset, ICON, result);
+		}
+		
+		//4. All Step-Proposals if any <space> and COMMA
+		else if(lastPrefix.matches(contentAssist.COMMA_SPACE_REGEX) |
+				!stepDetailList.isEmpty())
+		{
+			 // Don't Delete : Used For Debug
+			//System.out.println("stepDetailList NOT EMPTY......");
+			for(String step : stepDetailList)
+			{	
+				 // Don't Delete : Used For Debug
+				//System.out.println("stepDetailList ###########");
+				//Populate all step proposal
+				contentAssist.importStepProposals(lastPrefix, preStep, offset, ICON, step, result);
+			}
+		}
+
+		//5. No Match No Proposal
+		else
+		{
+			 // Don't Delete : Used For Debug
+			//System.out.println("NO PROPOSAL-3***************");
+			contentAssist.displayNoProposal(offset, ICON, result);
+		}
+	}
+
+	private void addStepWordCompletionProposal(int offset, String typed, ArrayList<ICompletionProposal> result,
+			String stepKeyWord) {
+		CompletionProposal p = new CompletionProposal(stepKeyWord, offset - typed.length(), typed.length(),stepKeyWord.length(), ICON, null, null, null);
+		result.add(p);
 	}
 
 	

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/ExtensionRegistryStepProvider.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/ExtensionRegistryStepProvider.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IProgressMonitor;
 
 import cucumber.eclipse.steps.integration.IStepDefinitions;
 import cucumber.eclipse.steps.integration.IStepListener;
@@ -23,7 +24,8 @@ public class ExtensionRegistryStepProvider implements IStepProvider, IStepListen
 	
 	public ExtensionRegistryStepProvider(IFile file) {
 		this.file = file;
-		reloadSteps();
+		//TODO can we obtain a progressmonitor somewhere?
+		reloadSteps(null);
 		addStepListener(this);
 	}
 
@@ -37,10 +39,10 @@ public class ExtensionRegistryStepProvider implements IStepProvider, IStepListen
 		return steps;
 	}
 
-	private void reloadSteps() {
+	private void reloadSteps(IProgressMonitor progressMonitor) {
 		steps.clear();
 		for (IStepDefinitions stepDef : stepDefinitions) {
-			steps.addAll(stepDef.getSteps(file));
+			steps.addAll(stepDef.getSteps(file, progressMonitor));
 		}
 	}
 
@@ -52,6 +54,7 @@ public class ExtensionRegistryStepProvider implements IStepProvider, IStepListen
 
 	@Override
 	public void onStepsChanged(StepsChangedEvent event) {
-		reloadSteps();
+		//TODO can we obtain a progressmonitor somewhere?
+		reloadSteps(null);
 	}
 }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/jdt/JDTStepDefinitions.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/jdt/JDTStepDefinitions.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -43,7 +44,7 @@ public class JDTStepDefinitions extends StepDefinitions implements IStepDefiniti
 	
 	// 1. To get Steps as Set from both Java-Source and JAR file
 	@Override
-	public Set<Step> getSteps(IFile featurefile) {
+	public Set<Step> getSteps(IFile featurefile, IProgressMonitor progressMonitor) {
 
 		// Commented By Girija to use LinkedHashSet Instead of HashSet
 		// Set<Step> steps = new HashSet<Step>();
@@ -76,7 +77,7 @@ public class JDTStepDefinitions extends StepDefinitions implements IStepDefiniti
 						// System.out.println("Package Name-1
 						// :"+javaPackage.getElementName());
 						// Collect All Steps From Source
-						collectCukeStepsFromSource(javaProject, javaPackage, steps);
+						collectCukeStepsFromSource(javaProject, javaPackage, steps, progressMonitor);
 					}
 
 					// Get Packages from JAR exists in class-path
@@ -105,15 +106,16 @@ public class JDTStepDefinitions extends StepDefinitions implements IStepDefiniti
 	 * @param javaProject
 	 * @param javaPackage
 	 * @param steps
+	 * @param progressMonitor 
 	 * @throws JavaModelException
 	 * @throws CoreException
 	 */
-	public void collectCukeStepsFromSource(IJavaProject javaProject, IPackageFragment javaPackage, Set<Step> steps)
+	public void collectCukeStepsFromSource(IJavaProject javaProject, IPackageFragment javaPackage, Set<Step> steps, IProgressMonitor progressMonitor)
 			throws JavaModelException, CoreException {
 
 		for (ICompilationUnit iCompUnit : javaPackage.getCompilationUnits()) {
 			// Collect and add Steps
-			steps.addAll(getCukeSteps(javaProject, iCompUnit));
+			steps.addAll(getCukeSteps(javaProject, iCompUnit, progressMonitor));
 		}
 	}
 
@@ -128,6 +130,7 @@ public class JDTStepDefinitions extends StepDefinitions implements IStepDefiniti
 	public void collectCukeStepsFromJar(IPackageFragment javaPackage, Set<Step> steps)
 			throws JavaModelException, CoreException {
 
+		@SuppressWarnings("deprecation")
 		IClassFile[] classFiles = javaPackage.getClassFiles();
 		for (IClassFile classFile : classFiles) {
 			// System.out.println("----classFile: "

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/IStepDefinitions.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/IStepDefinitions.java
@@ -3,12 +3,13 @@ package cucumber.eclipse.steps.integration;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IProgressMonitor;
 
 public interface IStepDefinitions {
 
     void addStepListener(IStepListener listener);
 
-    Set<Step> getSteps(IFile featurefile);
+    Set<Step> getSteps(IFile featurefile, IProgressMonitor progressMonitor);
 
     void removeStepListener(IStepListener listener);
 }

--- a/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaParser.java
+++ b/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaParser.java
@@ -9,9 +9,8 @@ import java.util.Set;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IImportDeclaration;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.IProblem;
@@ -35,22 +34,15 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 public class JavaParser extends AbstractHandler {
 
 	private ASTParser astParser = null;
-	private IResource source = null;
-	private static CompilationUnit compUnit = null;
-	private List<Statement> statementList = null;
+	private CompilationUnit compUnit = null;
 	private ASTRequestor astRequestor = null;
 
 	private String className = null;
 	private String methodBody = null;
-	private String importDeclaration = null;
-	private int lineNumber = 0;
-
-	public JavaParser() {
-
-	}
 
 	// Initialize ASTParser as CompilationUnit
-	public JavaParser(ICompilationUnit iCompilationUnit) {
+	@SuppressWarnings("deprecation")
+	public JavaParser(ICompilationUnit iCompilationUnit, IProgressMonitor progressMonitor) {
 
 		// astParser = ASTParser.newParser(AST.JLS3); //for jdk-7
 		this.astParser = ASTParser.newParser(AST.JLS8); // for jdk-8
@@ -61,7 +53,7 @@ public class JavaParser extends AbstractHandler {
 		astParser.setCompilerOptions(Collections.singletonMap(JavaCore.COMPILER_PB_UNUSED_IMPORT, JavaCore.ERROR));
 		astParser.setSource(iCompilationUnit);
 		astParser.setResolveBindings(true);
-		compUnit = (CompilationUnit) astParser.createAST(null);
+		compUnit = (CompilationUnit) astParser.createAST(progressMonitor);
 	}
 
 	/**
@@ -86,26 +78,7 @@ public class JavaParser extends AbstractHandler {
 		this.methodBody = method.getBody().toString();
 		return methodBody;
 	}
-
-	/**
-	 * @param method
-	 * @return List<Statement>
-	 */
-	@SuppressWarnings("unchecked")
-	public List<Statement> getBodyStatements(MethodDeclaration method) {
-		this.statementList = method.getBody().statements();
-		return statementList;
-	}
-
-	/**
-	 * @param iCompUnit
-	 * @return String
-	 */
-
-	public IResource getSource(ICompilationUnit iCompUnit) {
-		this.source = iCompUnit.getResource();
-		return source;
-	}
+	
 
 	/**
 	 * @param iCompUnit
@@ -123,18 +96,9 @@ public class JavaParser extends AbstractHandler {
 	 * @return int
 	 */
 	public int getLineNumber(Statement statement) {
-		this.lineNumber = compUnit.getLineNumber(statement.getStartPosition());
-		return lineNumber;
+		return compUnit.getLineNumber(statement.getStartPosition());
 	}
 
-	/**
-	 * @param importDecl
-	 * @return String
-	 */
-	public String getImportStatement(IImportDeclaration iImportDecl) {
-		this.importDeclaration = iImportDecl.getElementName();
-		return importDeclaration;
-	}
 
 	/**
 	 * Method Visitor


### PR DESCRIPTION
Currently Step-Definitions Codecompletion only works with English Language (Given, ...) but not with other Languages (e.g. German "Angenommen"...) this pull request fixes this by not rely on hard coded regular expressions but checking the language specific keywords directly.