### PR TITLE
Fix string literal syntax highlighting

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
@@ -45,8 +45,8 @@ public class GherkinKeywordScanner extends RuleBasedScanner {
 		rules.add(new EndOfLineRule("#", comment)); //$NON-NLS-1$
 
 		// Add rule for strings and character constants.
-		rules.add(new SingleLineRule("\"", "\"", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
-		rules.add(new SingleLineRule("'", "'", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
+		rules.add(new SingleLineRule(" \"", "\" ", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
+		rules.add(new SingleLineRule(" '", "' ", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
 
 		// Add rule for tags.
 		rules.add(new GherkinTagRule(tag));


### PR DESCRIPTION
Simple change to help reduce the number of false-positives for the string-literal syntax highlighting in the Cucumber Editor.  

Current Highlighting (before the change):
![original_screenshot](https://user-images.githubusercontent.com/8441903/45601620-9f80ef80-b9d5-11e8-916c-410c6762af81.png)

New Highlighting (after the change):
![updated_screenshot](https://user-images.githubusercontent.com/8441903/45601621-a6a7fd80-b9d5-11e8-9e85-2920d16b6623.png)

Fixes https://github.com/cucumber/cucumber-eclipse/issues/83 and https://github.com/cucumber/cucumber-eclipse/issues/91