### PR TITLE
Fix/missing glue icon

### DIFF
--- a/cucumber.eclipse.steps.integration/build.properties
+++ b/cucumber.eclipse.steps.integration/build.properties
@@ -5,4 +5,5 @@ bin.includes = META-INF/,\
                plugin.xml,\
                META-INF/lib/cucumber-core-1.2.5.jar,\
                META-INF/lib/gherkin-2.12.2.jar,\
-               META-INF/lib/cucumber-expressions-6.2.0.jar
+               META-INF/lib/cucumber-expressions-6.2.0.jar,\
+               icons/


### PR DESCRIPTION
This pull request only adds the glue.gif to the ZIP archive.
It was simply unchecked in the binary build.

Fix #308 