### PR TITLE
Enable travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: java
+sudo: false
+
+cache:
+  directories:
+  - "$HOME/.m2"
+
 jdk:
   - oraclejdk8
   - openjdk11
   - openjdk-ea
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ cache:
 
 jdk:
   - oraclejdk8
-  - openjdk11
-  - openjdk-ea
 
-
-jobs:  
-  include:
-    - stage: "Tests"                # naming the Tests stage
-      name: "Unit Tests"            # names the first Tests stage job
-      script: mvn test -B
+#jobs:  
+#  include:
+#    - stage: "Tests"                # naming the Tests stage
+#      name: "Unit Tests"            # names the first Tests stage job
+#      script: mvn test -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk11
+  - openjdk-ea
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,10 @@ jdk:
   - oraclejdk8
   - openjdk11
   - openjdk-ea
+
+
+jobs:  
+  include:
+    - stage: "Tests"                # naming the Tests stage
+      name: "Unit Tests"            # names the first Tests stage job
+      script: mvn test -B


### PR DESCRIPTION
Add a simple configuration for Travis CI.
This one launches a build with `mvn test -B` and `oraclejdk8`.
Travis will built any branches when a new pull request is submitted.

