### PR TITLE
Cucumber builder should continue the step definitions scan even if the search engine failed

### DIFF
--- a/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionsProvider.java
+++ b/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionsProvider.java
@@ -445,8 +445,14 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 			};
 
 			for (IJavaSearchScope scope : scopes) {
-				engine.search(searchPattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, scope,
-						requestor, null);	
+				try {
+					engine.search(searchPattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, scope,
+							requestor, null);
+				}
+				catch (Throwable t) {
+					t.printStackTrace();
+					// if the search engine failed, skip it is a bug into the JDT plugin
+				}
 			}
 			
 			return stepDefinitions;


### PR DESCRIPTION
The step definitions provider for Java uses the Eclipse JDT search engine to detect step definitions from the classpath.
If the search engine failed, the builder should continue silently. Thus, the step definitions from the classpath will be probably incomplete but it is less bad than return nothing.

Fix #313 