### PR TITLE
Add a warn marker & a quick fix when a feature file is opened from non cucumber project

### DIFF
--- a/cucumber.eclipse.editor/plugin.xml
+++ b/cucumber.eclipse.editor/plugin.xml
@@ -226,6 +226,11 @@
          markerType="cucumber.eclipse.marker.gherkin.unmatched_step"
          class="cucumber.eclipse.editor.markers.StepCreationMarkerResolutionGenerator"/>
    </extension>
+   <extension point="org.eclipse.ui.ide.markerResolution">
+      <markerResolutionGenerator
+         markerType="cucumber.eclipse.marker.not_a_cucumber_project"
+         class="cucumber.eclipse.editor.markers.ConfigureAsCucumberProjectMarkerResolutionGenerator"/>
+   </extension>
     <extension
           point="org.eclipse.ui.contexts">
        <context
@@ -298,7 +303,7 @@
  </extension> 
  <extension 
     id="cucumber.eclipse.nature" 
-    name="Cucumber Incremental" 
+    name="Cucumber" 
     point="org.eclipse.core.resources.natures">
 	<runtime>
 		<run class="cucumber.eclipse.editor.nature.CucumberProjectNature"/> 

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
@@ -29,7 +29,9 @@ import org.eclipse.ui.editors.text.TextEditor;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 
 import cucumber.eclipse.editor.Activator;
+import cucumber.eclipse.editor.nature.CucumberProjectNature;
 import cucumber.eclipse.editor.template.GherkinSampleTemplate;
+import cucumber.eclipse.steps.integration.marker.MarkerFactory;
 
 public class Editor extends TextEditor {
 
@@ -145,11 +147,21 @@ public class Editor extends TextEditor {
 	protected void doSetInput(IEditorInput newInput) throws CoreException {
 		super.doSetInput(newInput);
 		model = new GherkinModel();
-
+		this.warnIfFeatureFileOpenedComesFromNonCucumberProject();
 	}
 
+	private void warnIfFeatureFileOpenedComesFromNonCucumberProject() throws CoreException {
+		IFile featureFile = this.getFile();
+		boolean isCucumberProject = featureFile.getProject().hasNature(CucumberProjectNature.ID);
+		if(!isCucumberProject) {
+			MarkerFactory markerFactory = MarkerFactory.INSTANCE;
+			markerFactory.featureFileIsNotInCucumberProject(featureFile);
+		}
+	}
+	
+	
 	public IFile getFile() {
-		IFileEditorInput fileEditorInput = (IFileEditorInput) this.getEditorInput();
+ 		IFileEditorInput fileEditorInput = (IFileEditorInput) this.getEditorInput();
 		return fileEditorInput.getFile();
 	}
 

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/Editor.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -152,7 +153,8 @@ public class Editor extends TextEditor {
 
 	private void warnIfFeatureFileOpenedComesFromNonCucumberProject() throws CoreException {
 		IFile featureFile = this.getFile();
-		boolean isCucumberProject = featureFile.getProject().hasNature(CucumberProjectNature.ID);
+		IProject projectWithGherkinFile = featureFile.getProject();
+		boolean isCucumberProject = projectWithGherkinFile.hasNature(CucumberProjectNature.ID);
 		if(!isCucumberProject) {
 			MarkerFactory markerFactory = MarkerFactory.INSTANCE;
 			markerFactory.featureFileIsNotInCucumberProject(featureFile);

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/handler/AddNatureHandler.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/handler/AddNatureHandler.java
@@ -3,20 +3,13 @@ package cucumber.eclipse.editor.handler;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IProjectDescription;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.handlers.HandlerUtil;
 
 import cucumber.eclipse.editor.nature.CucumberProjectNature;
-import cucumber.eclipse.steps.integration.builder.BuilderUtil;
-import cucumber.eclipse.steps.integration.marker.MarkerFactory;
 
 
 public class AddNatureHandler extends AbstractHandler {
@@ -29,7 +22,10 @@ public class AddNatureHandler extends AbstractHandler {
 	            ? ((IAdaptable) selection).getAdapter(IProject.class) : null);
 	    
 	    try {
-            addNature(project);
+	    	CucumberProjectNature cucumberProjectNature = new CucumberProjectNature();
+	    	cucumberProjectNature.setProject(project);
+	    	cucumberProjectNature.configure();
+	    	
         } catch (CoreException e) {
             throw new ExecutionException("Error adding nature", e);
         }
@@ -37,24 +33,4 @@ public class AddNatureHandler extends AbstractHandler {
 		return null;
 	}
 
-    private void addNature(IProject project) throws CoreException {
-        IProjectDescription description = project.getDescription();
-	    String[] oldNatures = description.getNatureIds();
-	    String[] newNatures = new String[oldNatures.length+1];
-	    newNatures[0] = CucumberProjectNature.ID;
-	    for (int it=0; it<oldNatures.length; it++) {
-	    	String nature = oldNatures[it];
-			if(CucumberProjectNature.ID.equals(nature)) {
-				return ; // change nothing
-			}
-			newNatures[it+1] = nature;
-		}
-	    description.setNatureIds(newNatures);
-	    project.setDescription(description, new NullProgressMonitor());
-	    MarkerFactory.INSTANCE.cleanCucumberNatureMissing(project);
-		BuilderUtil.buildProject(project, IncrementalProjectBuilder.FULL_BUILD);
-
-    }
-    
-   
 }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/i18n/CucumberEditorMessages.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/i18n/CucumberEditorMessages.java
@@ -1,0 +1,19 @@
+package cucumber.eclipse.editor.i18n;
+
+import org.eclipse.osgi.util.NLS;
+
+public class CucumberEditorMessages extends NLS {
+
+	private static final String BUNDLE_NAME = "cucumber.eclipse.editor.i18n.CucumberEditorMessages"; //$NON-NLS-1$
+
+    public static String MarkerResolution__Configure_as_cucumber_project;
+
+	static {
+		// load message values from bundle file
+		NLS.initializeMessages(BUNDLE_NAME, CucumberEditorMessages.class);
+	}
+	
+}
+
+
+

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/i18n/CucumberEditorMessages.properties
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/i18n/CucumberEditorMessages.properties
@@ -1,0 +1,1 @@
+MarkerResolution__Configure_as_cucumber_project=Configure {0} as Cucumber project

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/markers/ConfigureAsCucumberProjectMarkerResolutionGenerator.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/markers/ConfigureAsCucumberProjectMarkerResolutionGenerator.java
@@ -1,0 +1,78 @@
+package cucumber.eclipse.editor.markers;
+
+import static cucumber.eclipse.steps.integration.marker.MarkerFactory.NOT_A_CUCUMBER_PROJECT;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.ui.IMarkerResolution;
+import org.eclipse.ui.IMarkerResolutionGenerator2;
+
+import cucumber.eclipse.editor.i18n.CucumberEditorMessages;
+import cucumber.eclipse.editor.nature.CucumberProjectNature;
+
+/**
+ * Quick fix to configure a project when the editor detected
+ * a gherkin source file from a project without the cucumber nature.
+ * 
+ * @author qvdk
+ *
+ */
+public class ConfigureAsCucumberProjectMarkerResolutionGenerator implements IMarkerResolutionGenerator2 {
+
+	/**
+	 * @see org.eclipse.ui.IMarkerResolutionGenerator#getResolutions(org.eclipse.core.resources.IMarker)
+	 */
+	@Override
+	public IMarkerResolution[] getResolutions(IMarker marker) {
+
+		if (!hasResolutions(marker)) {
+			return new IMarkerResolution[0];
+		}
+
+		return new IMarkerResolution[] { new ConfigureAsCucumberProjectMarkerResolution(marker.getResource().getProject()) };
+	}
+
+	@Override
+	public boolean hasResolutions(IMarker marker) {
+		boolean hasResolutions = false;
+		try {
+			hasResolutions = NOT_A_CUCUMBER_PROJECT.equals(marker.getType());
+		} catch (CoreException e) {
+			e.printStackTrace();
+			hasResolutions = false;
+		}
+		return hasResolutions;
+	}
+
+	private class ConfigureAsCucumberProjectMarkerResolution implements IMarkerResolution {
+
+		private IProject project;
+		
+		public ConfigureAsCucumberProjectMarkerResolution(IProject project) {
+			super();
+			this.project = project;
+		}
+
+		@Override
+		public String getLabel() {
+			return NLS.bind(CucumberEditorMessages.MarkerResolution__Configure_as_cucumber_project, project.getName());
+		}
+
+		@Override
+		public void run(IMarker marker) {
+			try {
+				CucumberProjectNature cucumberProjectNature = new CucumberProjectNature();
+				cucumberProjectNature.setProject(project);
+				cucumberProjectNature.configure();
+				
+				marker.delete();
+				
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
+		}
+		
+	}
+}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/nature/CucumberProjectNature.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/nature/CucumberProjectNature.java
@@ -49,6 +49,7 @@ public class CucumberProjectNature implements IProjectNature {
 
     public void deconfigure() throws CoreException {
     	removeBuilder(project);
+    	MarkerFactory.INSTANCE.cleanMarkersRecursively(project);
     }
 
     public IProject getProject() {

--- a/cucumber.eclipse.feature/feature.xml
+++ b/cucumber.eclipse.feature/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="cucumber.eclipse.feature"
-      label="Cucumber Eclipse Feature"
+      label="Cucumber Eclipse"
       version="1.0.0.qualifier">
 
    <description>

--- a/cucumber.eclipse.steps.integration/plugin.xml
+++ b/cucumber.eclipse.steps.integration/plugin.xml
@@ -62,6 +62,15 @@
 	  	<super type="cucumber.eclipse.marker"/>
 	  	<persistent value="true"/>
 	</extension>
+	<extension
+	    id="cucumber.eclipse.marker.not_a_cucumber_project"
+	    name="Project without Cucumber nature"
+	    point="org.eclipse.core.resources.markers">
+	    <super type="org.eclipse.core.resources.problemmarker"/>
+	  	<super type="cucumber.eclipse.marker"/>
+	  	<attribute name="cucumber.eclipse.marker.not_a_cucumber_project.project_name"/>
+	  	<persistent value="true"/>
+	</extension>
    <extension
          point="org.eclipse.ui.editors.markerAnnotationSpecification">
       <specification

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/i18n/CucumberStepsIntegrationMessages.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/i18n/CucumberStepsIntegrationMessages.java
@@ -1,0 +1,20 @@
+package cucumber.eclipse.steps.integration.i18n;
+
+import org.eclipse.osgi.util.NLS;
+
+public class CucumberStepsIntegrationMessages extends NLS {
+
+	private static final String BUNDLE_NAME = "cucumber.eclipse.steps.integration.i18n.CucumberStepsIntegrationMessages"; //$NON-NLS-1$
+
+    public static String MarkerFactory__Step_definitions_detection_not_working_on_non_cucumber_project;
+
+
+	static {
+		// load message values from bundle file
+		NLS.initializeMessages(BUNDLE_NAME, CucumberStepsIntegrationMessages.class);
+	}
+	
+}
+
+
+

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/i18n/CucumberStepsIntegrationMessages.properties
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/i18n/CucumberStepsIntegrationMessages.properties
@@ -1,0 +1,1 @@
+MarkerFactory__Step_definitions_detection_not_working_on_non_cucumber_project=Step definitions detection works only when the project is configured as cucumber project.

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/marker/MarkerFactory.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/marker/MarkerFactory.java
@@ -282,17 +282,18 @@ public class MarkerFactory {
 
 	}
 	
-	public void featureFileIsNotInCucumberProject(IFile gherkinFile) {
-		this.mark(gherkinFile, new IMarkerBuilder() {
+	public void featureFileIsNotInCucumberProject(IFile project) {
+		this.mark(project, new IMarkerBuilder() {
 			@Override
 			public IMarker build() {
 				IMarker marker = null;
 				try {
-					marker = gherkinFile.createMarker(NOT_A_CUCUMBER_PROJECT);
+					project.deleteMarkers(NOT_A_CUCUMBER_PROJECT, true, IResource.DEPTH_ZERO);
+					marker = project.createMarker(NOT_A_CUCUMBER_PROJECT);
 					marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
 					marker.setAttribute(IMarker.MESSAGE, CucumberStepsIntegrationMessages.MarkerFactory__Step_definitions_detection_not_working_on_non_cucumber_project);
 					marker.setAttribute(IMarker.LINE_NUMBER, 1);
-					marker.setAttribute(NOT_A_CUCUMBER_PROJECT_NAME_ATTRIBUTE, gherkinFile.getProject().getName());
+					marker.setAttribute(NOT_A_CUCUMBER_PROJECT_NAME_ATTRIBUTE, project.getName());
 				} catch (CoreException e) {
 					e.printStackTrace();
 				}
@@ -310,6 +311,15 @@ public class MarkerFactory {
 		}
 	}
 
+	public void cleanMarkersRecursively(IResource resource) {
+		try {
+			resource.deleteMarkers(CUCUMBER_MARKER, true, IResource.DEPTH_INFINITE);
+		} catch (CoreException e) {
+			Activator.getDefault().getLog().log(new Status(IStatus.ERROR, Activator.PLUGIN_ID,
+					String.format("Couldn't remove markers from %s", resource), e));
+		}
+	}
+	
 	private void mark(final IResource resource, final IMarkerBuilder markerBuilder) {
 		try {
 			IWorkspaceRunnable runnable = new IWorkspaceRunnable() {


### PR DESCRIPTION
Fixes #320 

This pull request allows to alert the user when he opened a gherkin file from a project without the cucumber nature.
In this case, the user can have the dedicated editor with syntax highlight, but the step definitions detection is not enabled. 

Indeed, the user have to configure his project as a Cucumber project in order to enable the cucumber builders in charge of resolving step definitions.

Thus, this pull request introduces an alert to notify the user should configure his project. More, a quick fix can be used to facilitate this setup.

![screencast-from-13-01-2019-21_34_57](https://user-images.githubusercontent.com/6142398/51090417-fa580700-177b-11e9-9c5a-10716571c4c9.gif)

