### PR TITLE
filter out files checked by builder

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
@@ -174,7 +174,7 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 			// `${project.build.directory}/test-classes`
 			// but we do not need this files since we already parse sources.
 			if (resource.getFullPath().toString().contains("test-classes")) {
-				return true;
+				return false;
 			}
 			// end of the very bad hack...
 


### PR DESCRIPTION
I think that if a resource is in /test-classes, then all its children are too, so there is no need to have the builder run on them.