### PR TITLE
force full rebuild less often

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
@@ -192,7 +192,7 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 				// then we shall rebuild all gherkins files because this step definitions file
 				// could add glue to any of gherkins steps.
 
-				if (isIncrementalBuild && stepDefinitionsProvider.support(getProject())) {
+				if (isIncrementalBuild && stepDefinitionsProvider.support(file)) {
 					// force a full build of gherkin files
 					fullBuild(glueDetectionEnabled, monitor);
 				}


### PR DESCRIPTION
I think that if a resource is in /test-classes, then all its children are too, so there is no need to have the builder run on them.