### PR TITLE
Remove unnecessary parsing of the step expression

### DIFF
--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/StepDefinition.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/StepDefinition.java
@@ -37,7 +37,6 @@ public class StepDefinition implements Serializable {
 	}
 	public void setText(String text) throws CucumberExpressionException {
 		this.text = text;
-		this.initExpressionFactory();
 	}
 	
 	private void initExpressionFactory() {


### PR DESCRIPTION
Fix #336 

This PR removes an unnecessary parsing of cucumber expression when using <kbd>CTRL</kbd>+<kbd>clic</kbd>.
This one threw a `CucumberExpressionException` when creating the `StepDefinition` object. In this case, the step definition is used to create an hyperlink which does not require to evaluate the expression. More, this evaluation was redundant since it is also done by `matches` method.

With this fix, it is possible to jump to step definition like this one.
![sample](https://user-images.githubusercontent.com/6142398/52015514-72476080-24e2-11e9-8fd0-c70fdd4e526d.png)
