### PR TITLE
Reduce the incremental build job to the strict necessary

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
@@ -157,6 +157,12 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 			}
 
 			if (!(resource instanceof IFile)) {
+				if(resource instanceof IProject) {
+					boolean projectConfigurationChanged = (delta.getFlags() & IResourceDelta.DESCRIPTION) != 0;
+					if(projectConfigurationChanged) {
+						fullBuildRequired = true;
+					}
+				}
 				return true;
 			}
 			

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
@@ -27,6 +27,8 @@ import org.eclipse.jface.text.IDocument;
 import cucumber.eclipse.editor.steps.BuildStorage;
 import cucumber.eclipse.editor.steps.GlueRepository;
 import cucumber.eclipse.editor.steps.GlueStorage;
+import cucumber.eclipse.editor.steps.StepDefinitionsRepository;
+import cucumber.eclipse.editor.steps.StepDefinitionsStorage;
 import cucumber.eclipse.editor.steps.UniversalStepDefinitionsProvider;
 import cucumber.eclipse.editor.util.FileUtil;
 import cucumber.eclipse.steps.integration.Activator;
@@ -157,6 +159,12 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 			if (!(resource instanceof IFile)) {
 				return true;
 			}
+			
+			int flags = delta.getFlags();
+			boolean contentChanged = (flags & IResourceDelta.CONTENT) != 0;
+			if(!contentChanged) {
+				return true;
+			}
 
 			// start of a very bad hack... see CucumberGherkinBuildVisitor
 			if (resource.getFullPath().toString().contains("test-classes")) {
@@ -174,7 +182,9 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 					// in this case there are nothing to do
 					return true;
 				}
-				if (stepDefinitionsProvider.support(file)) {
+				StepDefinitionsRepository stepDefinitionsRepository = StepDefinitionsStorage.INSTANCE.getOrCreate(getProject());
+				boolean isStepDefinitionsResource = stepDefinitionsRepository.isStepDefinitionsResource(resource); 
+				if (isStepDefinitionsResource && stepDefinitionsProvider.support(file)) {
 					// force a full build of gherkin files
 					fullBuildRequired = true;
 				}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberStepDefinitionsBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberStepDefinitionsBuilder.java
@@ -139,11 +139,22 @@ public class CucumberStepDefinitionsBuilder extends IncrementalProjectBuilder {
 			if(monitor.isCanceled()) {
 				return false;
 			}
-						
-			IResource resource = delta.getResource();
-//			System.out.println("CucumberIncrementalBuildVisitor is building " + delta.getResource().getName());
+			
+			int flags = delta.getFlags();
+			
+			boolean contentChanged = (flags & IResourceDelta.CONTENT) != 0;
+			boolean projectDescriptionChanged = (flags & IResourceDelta.DESCRIPTION) != 0;
+			
+			// process build only if the project configuration changed 
+			// or the resource changed
+			if(contentChanged || projectDescriptionChanged) {
+				IResource resource = delta.getResource();
+//				System.out.println("CucumberIncrementalBuildVisitor is building " + delta.getResource().getName());
 
-			return visit(resource);
+				return visit(resource);
+			}
+			
+			return true;
 		}
 
 	}


### PR DESCRIPTION
Fix #325

The Cucumber builder is launched too often because  

- a gherkin full build was launched on an update of a non-step definitions file (a java file without step definitions) 

- the incremental build is launched independently of the nature of the resource change, this one should be started only on resource content change

More, a full build of the gherkin builder is now launched if the project description changed. Indeed, the glue is not computed when a maven dependency was added. But in some case, this one could contains step definitions.