### PR TITLE
Preparation for Issue291 improve stepdefinition data model

### DIFF
--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepHyperlinkTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/editors/StepHyperlinkTest.java
@@ -4,12 +4,15 @@ package cucumber.eclipse.editor.editors;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.UUID;
+
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 import org.junit.Before;
 import org.junit.Test;
 
 import cucumber.eclipse.editor.editors.jumpto.StepHyperlink;
+import cucumber.eclipse.steps.integration.ExpressionDefinition;
 import cucumber.eclipse.steps.integration.StepDefinition;
 
 public class StepHyperlinkTest {
@@ -20,8 +23,7 @@ public class StepHyperlinkTest {
 	@Before
 	public void setUp() {
 		region = new Region(0, 10);
-		StepDefinition step = new StepDefinition();
-		step.setText("Given I have a cat");
+		StepDefinition step = new StepDefinition(UUID.randomUUID().toString(), "", new ExpressionDefinition("Given I have a cat", "en"), null, 0, null, null);
 		stepHyperlink = new StepHyperlink(region, step);
 	}
 	

--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsRepositoryTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsRepositoryTest.java
@@ -1,10 +1,12 @@
 package cucumber.eclipse.editor.steps;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.*;
-import static cucumber.eclipse.editor.steps.StepDefinitionsRepository.*;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -15,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import cucumber.eclipse.editor.tests.MockFile;
+import cucumber.eclipse.steps.integration.ExpressionDefinition;
 import cucumber.eclipse.steps.integration.ResourceHelper;
 import cucumber.eclipse.steps.integration.StepDefinition;
 
@@ -48,7 +51,7 @@ public class StepDefinitionsRepositoryTest {
 	}
 	
 	private StepDefinition createStep(String text, int lineNo) {
-		return new StepDefinition(UUID.randomUUID().toString(), StepDefinition.NO_LABEL, StepDefinition.parseText("en", text), StepDefinition.NO_SOURCE, StepDefinition.NO_LINE_NUMBER, StepDefinition.NO_SOURCE_NAME, StepDefinition.NO_PACKAGE_NAME);
+		return new StepDefinition(UUID.randomUUID().toString(), StepDefinition.NO_LABEL, new ExpressionDefinition(text, "en"), StepDefinition.NO_SOURCE, StepDefinition.NO_LINE_NUMBER, StepDefinition.NO_SOURCE_NAME, StepDefinition.NO_PACKAGE_NAME);
 	}
 
 	@Test
@@ -87,10 +90,10 @@ public class StepDefinitionsRepositoryTest {
 
 	@Test
 	public void serialization() throws IOException, ClassNotFoundException {
-		String serialization = serialize(stepDefinitionsRepository);
-		assertThat(serialization, is(notNullValue()));
-		
-		StepDefinitionsRepository deserializedRepository = deserialize(serialization, new TestResourceHelper());
+		InputStream stream = StorageHelper.toStream(stepDefinitionsRepository, null);
+		assertNotNull(stream);
+		StorageHelper.RESOURCEHELPER = new TestResourceHelper();
+		StepDefinitionsRepository deserializedRepository = StorageHelper.fromStream(StepDefinitionsRepository.class, stream, null);
 		Set<StepDefinition> stepDefinitions = deserializedRepository.getAllStepDefinitions();
 		assertThat(stepDefinitions.size(), equalTo(3));
 		

--- a/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsRepositoryTest.java
+++ b/cucumber.eclipse.editor.test/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsRepositoryTest.java
@@ -7,6 +7,7 @@ import static cucumber.eclipse.editor.steps.StepDefinitionsRepository.*;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
@@ -25,17 +26,11 @@ public class StepDefinitionsRepositoryTest {
 	public void setUp() {
 		stepDefinitionsRepository = new StepDefinitionsRepository();
 		
-		StepDefinition stepDefinition1 = new StepDefinition();
-		stepDefinition1.setText("I buy {word}");
-		stepDefinition1.setLineNumber(21);
+		StepDefinition stepDefinition1 = createStep("I buy {word}",21);
 		
-		StepDefinition stepDefinition2 = new StepDefinition();
-		stepDefinition2.setText("I pay {int}");
-		stepDefinition2.setLineNumber(12);
+		StepDefinition stepDefinition2 = createStep("I pay {int}",12);
 		
-		StepDefinition stepDefinition3 = new StepDefinition();
-		stepDefinition3.setText("I add {int} and {int}");
-		stepDefinition3.setLineNumber(21);
+		StepDefinition stepDefinition3 = createStep("I add {int} and {int}", 21);
 		
 		Set<StepDefinition> steps = new HashSet<StepDefinition>();
 		steps.add(stepDefinition1);
@@ -52,6 +47,10 @@ public class StepDefinitionsRepositoryTest {
 
 	}
 	
+	private StepDefinition createStep(String text, int lineNo) {
+		return new StepDefinition(UUID.randomUUID().toString(), StepDefinition.NO_LABEL, StepDefinition.parseText("en", text), StepDefinition.NO_SOURCE, StepDefinition.NO_LINE_NUMBER, StepDefinition.NO_SOURCE_NAME, StepDefinition.NO_PACKAGE_NAME);
+	}
+
 	@Test
 	public void store() {
 		Set<StepDefinition> stepDefinitions = stepDefinitionsRepository.getAllStepDefinitions();

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
@@ -188,7 +188,7 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 					// in this case there are nothing to do
 					return true;
 				}
-				StepDefinitionsRepository stepDefinitionsRepository = StepDefinitionsStorage.INSTANCE.getOrCreate(getProject());
+				StepDefinitionsRepository stepDefinitionsRepository = StepDefinitionsStorage.INSTANCE.getOrCreate(getProject(), null);
 				boolean isStepDefinitionsResource = stepDefinitionsRepository.isStepDefinitionsResource(resource); 
 				if (isStepDefinitionsResource && stepDefinitionsProvider.support(file)) {
 					// force a full build of gherkin files
@@ -265,7 +265,7 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 
 			// System.out.println(String.format("gherkin %s builder compile: %s",
 			// (isIncrementalBuild ? "incremental" : "full"), resource));
-			GlueRepository glueRepository = glueStorage.getOrCreate(resource.getProject());
+			GlueRepository glueRepository = glueStorage.getOrCreate(resource.getProject(), null);
 			glueRepository.clean(resource);
 			this.markerFactory.cleanMarkers(resource);
 
@@ -328,7 +328,7 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 			this.gherkinDocument = document;
 			this.markerFactory = markerFactory;
 			this.isGlueDetectionEnabled = isGlueDetectionEnabled;
-			this.glueRepository = glueStorage.getOrCreate(this.project);
+			this.glueRepository = glueStorage.getOrCreate(this.project, null);
 		}
 
 		@Override
@@ -553,7 +553,7 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 			}
 
 			this.markerFactory.cleanMarkers(resource);
-			GlueRepository glueRepository = glueStorage.getOrCreate(getProject());
+			GlueRepository glueRepository = glueStorage.getOrCreate(getProject(), null);
 			glueRepository.clean(resource);
 
 			return true;

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/contentassist/CucumberContentAssist.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/contentassist/CucumberContentAssist.java
@@ -131,7 +131,7 @@ public class CucumberContentAssist {
 			for (StepDefinition step : importedSteps) {
 
 				// Get Step-Text
-				String stepText = getStepName(step.getText());
+				String stepText = getStepName(step.getExpression().getSource());
 
 				// Collect Steps from Source(.java) file Based on LineNumber
 				if (step.getLineNumber() != 0) {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/contentassist/CucumberContentAssist.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/contentassist/CucumberContentAssist.java
@@ -131,7 +131,7 @@ public class CucumberContentAssist {
 			for (StepDefinition step : importedSteps) {
 
 				// Get Step-Text
-				String stepText = getStepName(step.getExpression().getSource());
+				String stepText = getStepName(step.getExpression().getText());
 
 				// Collect Steps from Source(.java) file Based on LineNumber
 				if (step.getLineNumber() != 0) {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
@@ -30,7 +30,7 @@ class JumpToStepDefinition {
 			//Search step in repository
 			if (id != null) {
 				StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
-						.getOrCreate(gherkinFile.getProject());
+						.getOrCreate(gherkinFile.getProject(), null);
 				Set<StepDefinition> stepDefinitions = repository.getAllStepDefinitions();
 				for (StepDefinition step : stepDefinitions) {
 					if (id.equals(step.getId())) {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
@@ -1,6 +1,7 @@
 package cucumber.eclipse.editor.editors.jumpto;
 
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -10,46 +11,50 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
 import cucumber.eclipse.editor.Activator;
+import cucumber.eclipse.editor.steps.StepDefinitionsRepository;
+import cucumber.eclipse.editor.steps.StepDefinitionsStorage;
 import cucumber.eclipse.editor.util.ExtensionRegistryUtil;
 import cucumber.eclipse.steps.integration.IStepDefinitionOpener;
-import cucumber.eclipse.steps.integration.ResourceHelper;
 import cucumber.eclipse.steps.integration.StepDefinition;
 import cucumber.eclipse.steps.integration.marker.MarkerFactory;
 
 class JumpToStepDefinition {
-	
-	public static StepDefinition findStepDefinitionMatch(int selectionLineNumber, IFile gherkinFile) throws CoreException {
-		StepDefinition stepDefinition = null;
-		IMarker stepDefinitionMatchMarker = JumpToStepDefinition.findStepDefinitionMatchMarker(selectionLineNumber, gherkinFile);
-		if(stepDefinitionMatchMarker != null) {
-			String stepDefinitionPath = (String) stepDefinitionMatchMarker.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_PATH_ATTRIBUTE);
-			if(stepDefinitionPath == null) {
-				// unable to jump
-				return null;
+
+	public static StepDefinition findStepDefinitionMatch(int selectionLineNumber, IFile gherkinFile)
+			throws CoreException {
+		IMarker stepDefinitionMatchMarker = JumpToStepDefinition.findStepDefinitionMatchMarker(selectionLineNumber,
+				gherkinFile);
+		if (stepDefinitionMatchMarker != null) {
+			String id = (String) stepDefinitionMatchMarker
+					.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_JDT_HANDLE_IDENTIFIER_ATTRIBUTE);
+			//Search step in repository
+			if (id != null) {
+				StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
+						.getOrCreate(gherkinFile.getProject());
+				Set<StepDefinition> stepDefinitions = repository.getAllStepDefinitions();
+				for (StepDefinition step : stepDefinitions) {
+					if (id.equals(step.getId())) {
+						return step;
+					}
+				}
 			}
-			String stepDefinitionText = (String) stepDefinitionMatchMarker.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_TEXT_ATTRIBUTE);
-			Integer stepDefinitionLineNumber = (Integer) stepDefinitionMatchMarker.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_LINE_NUMBER_ATTRIBUTE);
-			
-			stepDefinition = new StepDefinition();
-			stepDefinition.setSource(new ResourceHelper().find(stepDefinitionPath));
-			stepDefinition.setText(stepDefinitionText);
-			stepDefinition.setLineNumber(stepDefinitionLineNumber);
 		}
-		return stepDefinition;
+		return null;
 	}
-	
-	public static IMarker findStepDefinitionMatchMarker(int selectionLineNumber, IFile gherkinFile) throws CoreException {
-		IMarker stepDefinitionMatchMarker = null; 
+
+	public static IMarker findStepDefinitionMatchMarker(int selectionLineNumber, IFile gherkinFile)
+			throws CoreException {
+		IMarker stepDefinitionMatchMarker = null;
 		IMarker[] markers = gherkinFile.findMarkers(MarkerFactory.STEP_DEFINTION_MATCH, false, IResource.DEPTH_ZERO);
 		for (IMarker marker : markers) {
 			Integer lineNumber = (Integer) marker.getAttribute(IMarker.LINE_NUMBER);
-			if(lineNumber.equals(selectionLineNumber)) {
+			if (lineNumber.equals(selectionLineNumber)) {
 				stepDefinitionMatchMarker = marker;
 				break;
 			}
 		}
 
-		if(stepDefinitionMatchMarker == null) {
+		if (stepDefinitionMatchMarker == null) {
 			return null;
 		}
 		return stepDefinitionMatchMarker;
@@ -59,7 +64,7 @@ class JumpToStepDefinition {
 		try {
 			List<IStepDefinitionOpener> openers = ExtensionRegistryUtil.getStepDefinitionOpener();
 			for (IStepDefinitionOpener opener : openers) {
-				if(opener.canOpen(stepDefinition)) {
+				if (opener.canOpen(stepDefinition)) {
 					opener.openInEditor(stepDefinition);
 					return;
 				}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
@@ -1,5 +1,7 @@
 package cucumber.eclipse.editor.editors.jumpto;
 
+import java.util.Set;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
@@ -12,7 +14,8 @@ import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.jface.text.hyperlink.IHyperlinkDetector;
 
 import cucumber.eclipse.editor.editors.Editor;
-import cucumber.eclipse.steps.integration.ResourceHelper;
+import cucumber.eclipse.editor.steps.StepDefinitionsRepository;
+import cucumber.eclipse.editor.steps.StepDefinitionsStorage;
 import cucumber.eclipse.steps.integration.StepDefinition;
 import cucumber.eclipse.steps.integration.marker.MarkerFactory;
 
@@ -52,21 +55,28 @@ public class StepHyperlinkDetector implements IHyperlinkDetector {
 				String stepDefinitionText = (String) stepDefinitionMatchMarker.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_TEXT_ATTRIBUTE);
 				Integer stepDefinitionLineNumber = (Integer) stepDefinitionMatchMarker.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_LINE_NUMBER_ATTRIBUTE);
 				
-				StepDefinition stepDefinition = new StepDefinition();
-				if(stepDefinitionPath != null) {
-					stepDefinition.setSource(new ResourceHelper().find(stepDefinitionPath));
-				}
-				stepDefinition.setText(stepDefinitionText);
-				stepDefinition.setLineNumber(stepDefinitionLineNumber);
-				stepDefinition.setJDTHandleIdentifier(stepDefinitionJDTHandleIdentifier);
-	
-				// define the hyperlink region
-				String textStatement = (String) stepDefinitionMatchMarker.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_TEXT_ATTRIBUTE);
-				int statementStartOffset = lineStartOffset + currentLine.indexOf(textStatement);
-	
-				IRegion stepRegion = new Region(statementStartOffset, textStatement.length());
+				String id = (String) stepDefinitionMatchMarker
+						.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_JDT_HANDLE_IDENTIFIER_ATTRIBUTE);
+				//Search step in repository
+				if (id != null) {
+					StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
+							.getOrCreate(gherkinFile.getProject());
+					Set<StepDefinition> stepDefinitions = repository.getAllStepDefinitions();
+					for (StepDefinition stepDefinition : stepDefinitions) {
+						if (id.equals(stepDefinition.getId())) {
+							// define the hyperlink region
+							String textStatement = (String) stepDefinitionMatchMarker.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_TEXT_ATTRIBUTE);
+							int statementStartOffset = lineStartOffset + currentLine.indexOf(textStatement);
 				
-				return new IHyperlink[] { new StepHyperlink(stepRegion, stepDefinition) };
+							IRegion stepRegion = new Region(statementStartOffset, textStatement.length());
+							
+							return new IHyperlink[] { new StepHyperlink(stepRegion, stepDefinition) };
+						}
+					}
+				}
+				
+				
+				
 			}
 		} catch (BadLocationException e1) {
 			e1.printStackTrace();

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
@@ -60,7 +60,7 @@ public class StepHyperlinkDetector implements IHyperlinkDetector {
 				//Search step in repository
 				if (id != null) {
 					StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
-							.getOrCreate(gherkinFile.getProject());
+							.getOrCreate(gherkinFile.getProject(), null);
 					Set<StepDefinition> stepDefinitions = repository.getAllStepDefinitions();
 					for (StepDefinition stepDefinition : stepDefinitions) {
 						if (id.equals(stepDefinition.getId())) {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/BuildStorage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/BuildStorage.java
@@ -6,7 +6,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 public interface BuildStorage<T> {
 
-	T getOrCreate(IProject project) throws CoreException;
+	T getOrCreate(IProject project, IProgressMonitor monitor) throws CoreException;
 
 	void add(IProject project, T glueRepository);
 

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueRepository.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueRepository.java
@@ -21,7 +21,6 @@ import org.eclipse.core.resources.IResource;
 
 import cucumber.eclipse.steps.integration.GherkinStepWrapper;
 import cucumber.eclipse.steps.integration.Glue;
-import cucumber.eclipse.steps.integration.SerializationHelper;
 import cucumber.eclipse.steps.integration.StepDefinition;
 import gherkin.I18n;
 import gherkin.formatter.model.Step;

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueRepository.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueRepository.java
@@ -1,6 +1,9 @@
 package cucumber.eclipse.editor.steps;
 
+import java.io.Externalizable;
 import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,12 +27,12 @@ import gherkin.I18n;
 import gherkin.formatter.model.Step;
 
 
-public class GlueRepository implements Serializable {
+public class GlueRepository implements Externalizable {
 	
 	private static final long serialVersionUID = -3784224573706686779L;
 
 	
-	private Map<GherkinStepWrapper, StepDefinition> glues = new HashMap<GherkinStepWrapper, StepDefinition>();
+	private final Map<GherkinStepWrapper, StepDefinition> glues = new HashMap<GherkinStepWrapper, StepDefinition>();
 	
 	protected GlueRepository() {
 	}
@@ -183,14 +186,24 @@ public class GlueRepository implements Serializable {
 		}
 	}
 	
-	public static String serialize(GlueRepository glueRepository) throws IOException {
-		return SerializationHelper.serialize(glueRepository.glues);
+	@Override
+	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+		glues.clear();
+		int items = in.readInt();
+		for (int i = 0; i < items; i++) {
+			GherkinStepWrapper wrapper = (GherkinStepWrapper) in.readObject();
+			glues.put(wrapper, StorageHelper.readStepDefinition(in));
+		}
+		
 	}
-	
-	public static GlueRepository deserialize(String glueRepositorySerialized) throws ClassNotFoundException, IOException {
-		Map<GherkinStepWrapper, StepDefinition> glues = SerializationHelper.deserialize(glueRepositorySerialized);
-		GlueRepository glueRepository = new GlueRepository();
-		glueRepository.glues = glues;
-		return glueRepository;
+
+	@Override
+	public void writeExternal(ObjectOutput out) throws IOException {
+		out.writeInt(glues.size());
+		for (Entry<GherkinStepWrapper, StepDefinition> entry : glues.entrySet()) {
+			out.writeObject(entry.getKey());
+			StorageHelper.writeStepDefinition(entry.getValue(), out);
+		}
+		
 	}
 }

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueStorage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueStorage.java
@@ -105,7 +105,9 @@ public class GlueStorage implements BuildStorage<GlueRepository> {
 				GlueRepository glueRepository = StorageHelper.fromStream(GlueRepository.class, inputStream, monitor);
 				glueRepositoryByProject.put(project, glueRepository);
 			}
-			//in case of error we must start over with a clean repository
+		} catch (RuntimeException e) {
+			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading StepDefinitionStore failed, a full rebuild of the project might be required", e));
+			glueRepositoryByProject.put(project, new GlueRepository());
 		} catch (IOException e) {
 			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading GlueStore failed, a full rebuild of the project might be required", e));
 			glueRepositoryByProject.put(project, new GlueRepository());

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueStorage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/GlueStorage.java
@@ -105,10 +105,13 @@ public class GlueStorage implements BuildStorage<GlueRepository> {
 				GlueRepository glueRepository = StorageHelper.fromStream(GlueRepository.class, inputStream, monitor);
 				glueRepositoryByProject.put(project, glueRepository);
 			}
+			//in case of error we must start over with a clean repository
 		} catch (IOException e) {
-			throw new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, e.getMessage(), e));
+			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading GlueStore failed, a full rebuild of the project might be required", e));
+			glueRepositoryByProject.put(project, new GlueRepository());
 		} catch (ClassNotFoundException e) {
-			throw new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, e.getMessage(), e));
+			glueRepositoryByProject.put(project, new GlueRepository());
+			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading GlueStore failed, a full rebuild of the project might be required", e));
 		}
 	}
 

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsRepository.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsRepository.java
@@ -4,6 +4,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -32,8 +33,9 @@ import cucumber.eclipse.steps.integration.StepDefinition;
  */
 public class StepDefinitionsRepository implements Externalizable {
 
+	private static final long serialVersionUID = -5426643465030832989L;
 	private final Map<IResource, Set<StepDefinition>> stepDefinitionsByResourceName = new HashMap<IResource, Set<StepDefinition>>();
-	public void add(IResource stepDefinitionsFile, Set<StepDefinition> steps) {
+	public synchronized void add(IResource stepDefinitionsFile, Set<StepDefinition> steps) {
 		if (steps.isEmpty()) {
 			this.stepDefinitionsByResourceName.remove(stepDefinitionsFile);
 		} else {
@@ -69,7 +71,7 @@ public class StepDefinitionsRepository implements Externalizable {
 
 
 	@Override
-	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+	public synchronized void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
 		stepDefinitionsByResourceName.clear();
 		int size = in.readInt();
 		for (int i = 0; i < size; i++) {
@@ -91,7 +93,7 @@ public class StepDefinitionsRepository implements Externalizable {
 	}
 
 	@Override
-	public void writeExternal(ObjectOutput out) throws IOException {
+	public synchronized void writeExternal(ObjectOutput out) throws IOException {
 		out.writeInt(stepDefinitionsByResourceName.size());
 		for (Entry<IResource, Set<StepDefinition>> entry : stepDefinitionsByResourceName.entrySet()) {
 			out.writeObject(entry.getKey().getFullPath().toString());

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsStorage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsStorage.java
@@ -81,7 +81,9 @@ public class StepDefinitionsStorage implements BuildStorage<StepDefinitionsRepos
 							inputStream, monitor);
 					this.add(project, repository);
 			}
-			//If an error occures then this means our stored data is incompatible and we must start with a fresh repository
+		} catch (RuntimeException e) {
+			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading StepDefinitionStore failed, a full rebuild of the project might be required", e));
+			this.add(project, new StepDefinitionsRepository());
 		} catch (IOException e) {
 			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading StepDefinitionStore failed, a full rebuild of the project might be required", e));
 			this.add(project, new StepDefinitionsRepository());

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsStorage.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StepDefinitionsStorage.java
@@ -2,6 +2,7 @@ package cucumber.eclipse.editor.steps;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InvalidClassException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -75,14 +76,18 @@ public class StepDefinitionsStorage implements BuildStorage<StepDefinitionsRepos
 			return;
 		}
 		try {
-			try(InputStream inputStream = buildFile.getContents()) {
-				StepDefinitionsRepository repository = StorageHelper.fromStream(StepDefinitionsRepository.class, inputStream, monitor);
-				this.add(project, repository);
+			try (InputStream inputStream = buildFile.getContents()) {
+					StepDefinitionsRepository repository = StorageHelper.fromStream(StepDefinitionsRepository.class,
+							inputStream, monitor);
+					this.add(project, repository);
 			}
+			//If an error occures then this means our stored data is incompatible and we must start with a fresh repository
 		} catch (IOException e) {
-			throw new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, e.getMessage(), e));
+			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading StepDefinitionStore failed, a full rebuild of the project might be required", e));
+			this.add(project, new StepDefinitionsRepository());
 		} catch (ClassNotFoundException e) {
-			throw new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, e.getMessage(), e));
+			Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "loading StepDefinitionStore failed, a full rebuild of the project might be required", e));
+			this.add(project, new StepDefinitionsRepository());
 		}
 	}
 

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StorageHelper.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/StorageHelper.java
@@ -10,6 +10,7 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -63,16 +64,26 @@ public class StorageHelper {
 			InputStream stream) throws CoreException {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Saving data", 100);
 		IFolder target = getOutputFolder(project);
-		SubMonitor child = subMonitor.newChild(10);
-		if (!target.exists()) {
-			target.create(true, true, child);
-		}
+		createFolder(target, subMonitor.newChild(10));
 		IFile buildFile = target.getFile(filename);
 		if (buildFile.exists()) {
 			buildFile.setContents(stream, true, false, subMonitor.newChild(90));
 		} else {
 			buildFile.create(stream, true, subMonitor.newChild(90));
 		}
+	}
+
+	private static void createFolder(IFolder folder, IProgressMonitor monitor) throws CoreException {
+		if (folder.exists()) {
+			return;
+		}
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 2);
+		IContainer parent = folder.getParent();
+		if (parent instanceof IFolder) {
+			IFolder parentFolder = (IFolder) parent;
+			createFolder(parentFolder, subMonitor.newChild(1));
+		}
+		folder.create(true, true, subMonitor.newChild(1));
 	}
 
 	static ResourceHelper RESOURCEHELPER = new ResourceHelper();

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/UniversalStepDefinitionsProvider.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/steps/UniversalStepDefinitionsProvider.java
@@ -39,7 +39,7 @@ public class UniversalStepDefinitionsProvider implements IStepDefinitionsProvide
 	}
 
 	public Set<StepDefinition> getStepDefinitions(IProject project) throws CoreException {
-		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project);
+		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project, null);
 		Set<StepDefinition> stepDefinitions = stepDefinitionsRepository.getAllStepDefinitions(); // step definitions of the current projects
 		
 		IProject[] referencedProjects = project.getReferencedProjects();
@@ -52,7 +52,7 @@ public class UniversalStepDefinitionsProvider implements IStepDefinitionsProvide
 	}
 
 	public Set<IFile> getStepDefinitionsFiles(IProject project) throws CoreException {
-		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project);
+		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project, null);
 		return stepDefinitionsRepository.getAllStepDefinitionsFiles();
 	}
 
@@ -65,7 +65,7 @@ public class UniversalStepDefinitionsProvider implements IStepDefinitionsProvide
 				stepDefinitionsProviders.size());
 
 		IProject project = stepDefinitionResource.getProject();
-		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project);
+		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project, null);
 
 		int stepDefinitionsCounter = 0;
 		for (IStepDefinitionsProvider stepDefinitionsService : stepDefinitionsProviders) {
@@ -90,7 +90,7 @@ public class UniversalStepDefinitionsProvider implements IStepDefinitionsProvide
 	}
 
 	public void clean(IProject project) throws CoreException {
-		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project);
+		StepDefinitionsRepository stepDefinitionsRepository = this.stepDefinitionsStorage.getOrCreate(project, null);
 		stepDefinitionsRepository.reset();
 	}
 

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/AbstractStepDefinitionsProvider.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/AbstractStepDefinitionsProvider.java
@@ -3,7 +3,6 @@ package cucumber.eclipse.steps.integration;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/ExpressionDefinition.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/ExpressionDefinition.java
@@ -1,0 +1,63 @@
+package cucumber.eclipse.steps.integration;
+
+/**
+ * A Stepexpresion contains the raw unparsed values for a step
+ * 
+ * @author Christoph Läubrich
+ *
+ */
+public final class ExpressionDefinition {
+
+	private final String text;
+	private final String lang;
+
+	public ExpressionDefinition(String text, String lang) {
+		this.text = text;
+		this.lang = lang;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public String getLang() {
+		return lang;
+	}
+
+	@Override
+	public String toString() {
+		return text + " (" + lang + ")";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((lang == null) ? 0 : lang.hashCode());
+		result = prime * result + ((text == null) ? 0 : text.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ExpressionDefinition other = (ExpressionDefinition) obj;
+		if (lang == null) {
+			if (other.lang != null)
+				return false;
+		} else if (!lang.equals(other.lang))
+			return false;
+		if (text == null) {
+			if (other.text != null)
+				return false;
+		} else if (!text.equals(other.text))
+			return false;
+		return true;
+	}
+
+}

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/ExpressionDefinition.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/ExpressionDefinition.java
@@ -12,6 +12,9 @@ public final class ExpressionDefinition {
 	private final String lang;
 
 	public ExpressionDefinition(String text, String lang) {
+		if (text == null) {
+			throw new IllegalArgumentException("text cant be null");
+		}
 		this.text = text;
 		this.lang = lang;
 	}

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/StepDefinition.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/StepDefinition.java
@@ -23,6 +23,7 @@ public final class StepDefinition {
 	public static final String NO_SOURCE_NAME = null;
 	public static final String NO_PACKAGE_NAME = null;
 	public static final String NO_LABEL = null;
+	public static final IResource NO_SOURCE = null;
 
 	private final IResource source;
 	private final int lineNumber;

--- a/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/marker/MarkerFactory.java
+++ b/cucumber.eclipse.steps.integration/src/main/java/cucumber/eclipse/steps/integration/marker/MarkerFactory.java
@@ -14,7 +14,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
-import org.eclipse.osgi.util.NLS;
 
 import cucumber.eclipse.steps.integration.Activator;
 import cucumber.eclipse.steps.integration.GherkinStepWrapper;
@@ -228,7 +227,7 @@ public class MarkerFactory {
 						marker.setAttribute(STEP_DEFINITION_MATCH_PATH_ATTRIBUTE,
 								stepDefinition.getSource().getFullPath().toString());
 					}
-					marker.setAttribute(STEP_DEFINITION_MATCH_JDT_HANDLE_IDENTIFIER_ATTRIBUTE, stepDefinition.getJDTHandleIdentifier());
+					marker.setAttribute(STEP_DEFINITION_MATCH_JDT_HANDLE_IDENTIFIER_ATTRIBUTE, stepDefinition.getId());
 					marker.setAttribute(STEP_DEFINITION_MATCH_LINE_NUMBER_ATTRIBUTE, stepDefinition.getLineNumber());
 					marker.setAttribute(STEP_DEFINITION_MATCH_TEXT_ATTRIBUTE, stepDefinitionText);
 				} catch (CoreException e) {

--- a/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionOpener.java
+++ b/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionOpener.java
@@ -2,13 +2,11 @@ package cucumber.eclipse.steps.jdt;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ui.JavaUI;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PartInitException;
 
 import cucumber.eclipse.steps.integration.IStepDefinitionOpener;
@@ -43,7 +41,7 @@ public class JavaStepDefinitionOpener implements IStepDefinitionOpener {
     }
 	
 	private IMember getMember(StepDefinition stepDefinition) {
-		String jdtHandleIdentifier = stepDefinition.getJDTHandleIdentifier();
+		String jdtHandleIdentifier = stepDefinition.getId();
 		if(jdtHandleIdentifier == null || jdtHandleIdentifier.isEmpty()) {
 			return null;
 		}

--- a/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionsProvider.java
+++ b/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionsProvider.java
@@ -78,7 +78,7 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 
 	// From Java-Source-File(.java) : Collect All Steps as List based on
 	// Cucumber-Annotations
-	
+
 	private List<StepDefinition> getCukeSteps(ICompilationUnit iCompUnit, MarkerFactory markerFactory,
 			IProgressMonitor progressMonitor) throws JavaModelException, CoreException {
 
@@ -165,7 +165,7 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 										}
 										int lineNumber = javaParser.getLineNumber(statement);
 										ExpressionDefinition expression;
-										expression = new ExpressionDefinition(method.getCukeLang(), lambdaStep);
+										expression = new ExpressionDefinition(lambdaStep, method.getCukeLang());
 										StepDefinition step = new StepDefinition(ifType.getHandleIdentifier(),
 												StepDefinition.NO_LABEL, expression, resource, lineNumber,
 												method.getMethodName(), t.getPackageFragment().getElementName());
@@ -185,8 +185,8 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 						if (cukeAnnotation != null) {
 							int lineNumber = getLineNumber(iCompUnit, annotation);
 							ExpressionDefinition expression;
-							expression = new ExpressionDefinition(cukeAnnotation.getLang(),
-									getAnnotationText(annotation));
+							expression = new ExpressionDefinition(getAnnotationText(annotation),
+									cukeAnnotation.getLang());
 							StepDefinition step = new StepDefinition(method.getHandleIdentifier(),
 									StepDefinition.NO_LABEL, expression, resource, lineNumber, method.getElementName(),
 									t.getPackageFragment().getElementName());
@@ -539,7 +539,7 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 				IJavaElement pkg = classFile.getParent();
 				IJavaElement jar = pkg.getParent();
 				ExpressionDefinition expression;
-				expression = new ExpressionDefinition(cukeAnnotation.getLang(), getAnnotationText(annotation));
+				expression = new ExpressionDefinition(getAnnotationText(annotation), cukeAnnotation.getLang());
 
 				String classFileName = classFile.getElementName();
 				String packageName = pkg.getElementName();

--- a/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionsProvider.java
+++ b/cucumber.eclipse.steps.jdt/src/main/java/cucumber/eclipse/steps/jdt/JavaStepDefinitionsProvider.java
@@ -113,14 +113,17 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 			JavaParser javaParser = null;
 			for (IType t : iCompUnit.getTypes()) {
 				// collect all steps from java8 lambdas
+				IResource resource = iCompUnit.getResource();
 				for (IType ifType : t.newTypeHierarchy(progressMonitor).getAllInterfaces()) {
 
 					if (ifType.isInterface() && ifType.getFullyQualifiedName().startsWith(CUCUMBER_API_JAVA8)) {
 						String[] superInterfaceNames = ifType.getSuperInterfaceNames();
 						for (String superIfName : superInterfaceNames) {
 							if (superIfName.endsWith(".LambdaGlueBase")) {
-								// we found a possible interface, now try to load the language...
-								// String lang = ifType.getElementName().toLowerCase();
+								// we found a possible interface, now try to
+								// load the language...
+								// String lang =
+								// ifType.getElementName().toLowerCase();
 								// init if not done in previous step..
 								if (javaParser == null) {
 									javaParser = new JavaParser(iCompUnit, progressMonitor);
@@ -138,7 +141,8 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 
 									// Get Method/Constructor-Block{...}
 									if (isCukeLambdaExpr(method, keyWords)) {
-										// Collect method-body as List of Statements
+										// Collect method-body as List of
+										// Statements
 										@SuppressWarnings("unchecked")
 										List<Statement> statementList = method.getBody().statements();
 										if (!statementList.isEmpty()) {
@@ -153,47 +157,51 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 								for (MethodDefinition method : methodDefList) {
 									// Iterate Method-Statements
 									for (Statement statement : method.getMethodBodyList()) {
-										// Add all lambda-steps to Step
-										StepDefinition step = new StepDefinition();
-										step.setSource(iCompUnit.getResource()); // source
 										String lambdaStep = method.getLambdaStep(statement, keyWords);
 										if (lambdaStep == null) {
 											continue;
 										}
 										int lineNumber = javaParser.getLineNumber(statement);
+										io.cucumber.cucumberexpressions.Expression expression;
 										try {
-											step.setText(lambdaStep); // step
-											step.setLineNumber(lineNumber); // line-number
-											step.setLang(method.getCukeLang()); // Language
-											steps.add(step);
+											expression = StepDefinition.parseText(method.getCukeLang(),
+													lambdaStep);
 										} catch (CucumberExpressionException e) {
-											markerFactory.syntaxErrorOnStepDefinition(iCompUnit.getResource(), e,
-													lineNumber);
+											markerFactory.syntaxErrorOnStepDefinition(resource, e, lineNumber);
+											// don't add erronours steps!
+											continue;
 										}
-
+										StepDefinition step = new StepDefinition(ifType.getHandleIdentifier(),
+												StepDefinition.NO_LABEL, expression, resource, lineNumber, method.getMethodName(),
+												t.getPackageFragment().getElementName());
+										steps.add(step);
 									}
 								}
 							}
 						}
 					}
 				}
-				// Collect all steps from Annotations used in the methods as per imported
+				// Collect all steps from Annotations used in the methods as per
+				// imported
 				// Annotations
 				for (IMethod method : t.getMethods()) {
 					for (IAnnotation annotation : method.getAnnotations()) {
 						CucumberAnnotation cukeAnnotation = getCukeAnnotation(importedAnnotations, annotation);
 						if (cukeAnnotation != null) {
 							int lineNumber = getLineNumber(iCompUnit, annotation);
-							StepDefinition step = new StepDefinition();
-							step.setSource(method.getResource());
-							step.setLineNumber(lineNumber);
-							step.setLang(cukeAnnotation.getLang());
-							steps.add(step);
+							io.cucumber.cucumberexpressions.Expression expression;
 							try {
-								step.setText(getAnnotationText(annotation));
+								expression = StepDefinition.parseText(cukeAnnotation.getLang(),
+										getAnnotationText(annotation));
 							} catch (CucumberExpressionException e) {
-								markerFactory.syntaxErrorOnStepDefinition(iCompUnit.getResource(), e, lineNumber);
+								markerFactory.syntaxErrorOnStepDefinition(resource, e, lineNumber);
+								// don't add erronours steps!
+								continue;
 							}
+							StepDefinition step = new StepDefinition(method.getHandleIdentifier(),
+									StepDefinition.NO_LABEL, expression, resource, lineNumber, method.getElementName(),
+									t.getPackageFragment().getElementName());
+							steps.add(step);
 						}
 					}
 
@@ -201,10 +209,11 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 			}
 
 		} catch (JavaModelException e) {
-			 System.out.println("Warning: could not process "+iCompUnit.getElementName());
+			System.out.println("Warning: could not process " + iCompUnit.getElementName());
 		}
 		long end = System.currentTimeMillis();
-		// System.out.println("getCukeSteps " + iCompUnit.getJavaProject().getElementName() + ": " +
+		// System.out.println("getCukeSteps " +
+		// iCompUnit.getJavaProject().getElementName() + ": " +
 		// iCompUnit.getElementName() + " " + (end - start) + " ms.");
 
 		return steps;
@@ -328,23 +337,22 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 		return "";
 	}
 
-	
-	
 	@Override
 	protected Set<StepDefinition> findStepDefinitionsFromSupportedResource(IResource stepDefinitionResource,
 			MarkerFactory markerFactory, IProgressMonitor monitor) throws CoreException {
-//		System.out.println("jdt.findStepDefintions on " + stepDefinitionFile.getName());
+		// System.out.println("jdt.findStepDefintions on " +
+		// stepDefinitionFile.getName());
 		// This IStepDefinitions scans only Java files from Java project
-		
-		if(stepDefinitionResource instanceof IProject) {
+
+		if (stepDefinitionResource instanceof IProject) {
 			IProject project = (IProject) stepDefinitionResource;
 			boolean isJavaProject = this.support(project);
-			if(isJavaProject) {
+			if (isJavaProject) {
 				IJavaProject javaProject = JavaCore.create(project);
-				return findStepDefinitionsInClasspath(javaProject, monitor);
+				return findStepDefinitionsInClasspath(javaProject, markerFactory, monitor);
 			}
 		}
-		
+
 		IProject project = stepDefinitionResource.getProject();
 
 		boolean isJavaProject = this.support(project);
@@ -363,7 +371,8 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 
 		if (CucumberJavaPreferences.isUseStepDefinitionsFilters()) {
 			String[] filters = CucumberJavaPreferences.getStepDefinitionsFilters();
-			CompilationUnitStepDefinitionsPreferencesFilter filter = new CompilationUnitStepDefinitionsPreferencesFilter(filters);
+			CompilationUnitStepDefinitionsPreferencesFilter filter = new CompilationUnitStepDefinitionsPreferencesFilter(
+					filters);
 			if (!filter.accept(compilationUnit)) {
 				// skip
 				return new HashSet<StepDefinition>();
@@ -386,18 +395,17 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 		return javaElement != null;
 	}
 
-
-	private Set<StepDefinition> findStepDefinitionsInClasspath(IJavaProject javaProject, IProgressMonitor monitor) throws CoreException {
+	private Set<StepDefinition> findStepDefinitionsInClasspath(IJavaProject javaProject, MarkerFactory markerFactory, IProgressMonitor monitor)
+			throws CoreException {
 
 		SearchPattern searchPattern = SearchPattern.createPattern("cucumber.api.java.*.*", IJavaSearchConstants.TYPE,
 				IJavaSearchConstants.IMPORT_DECLARATION_TYPE_REFERENCE,
 				SearchPattern.R_PATTERN_MATCH | SearchPattern.R_CASE_SENSITIVE);
 
-		
 		try {
 			SearchEngine engine = new SearchEngine();
 			IJavaSearchScope[] scopes = this.computeScope(engine, javaProject, monitor);
-			
+
 			final Set<StepDefinition> stepDefinitions = new HashSet<StepDefinition>();
 			SearchRequestor requestor = new SearchRequestor() {
 				private long start, end;
@@ -423,28 +431,25 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 
 							if (match.getElement() instanceof IMethod) {
 								IMethod method = (IMethod) match.getElement();
-								
-								Set<StepDefinition> methodStepDefinitions = getCukeSteps(method);
-								if(methodStepDefinitions != null) {
+
+								Set<StepDefinition> methodStepDefinitions = getCukeSteps(method, markerFactory);
+								if (methodStepDefinitions != null) {
 									stepDefinitions.addAll(methodStepDefinitions);
 								}
 
-							}
-							else if (match.getElement() instanceof IType) {
+							} else if (match.getElement() instanceof IType) {
 								IType resolvedType = (IType) match.getElement();
-								
+
 								IMethod[] methods = resolvedType.getMethods();
 								for (IMethod method : methods) {
-									Set<StepDefinition> methodStepDefinitions = getCukeSteps(method);
-									if(methodStepDefinitions != null) {
+									Set<StepDefinition> methodStepDefinitions = getCukeSteps(method, markerFactory);
+									if (methodStepDefinitions != null) {
 										stepDefinitions.addAll(methodStepDefinitions);
 									}
 								}
 							}
 						}
 
-					} catch (CucumberExpressionException e) {
-						e.printStackTrace();
 					} catch (JavaModelException e) {
 						e.printStackTrace();
 					}
@@ -454,7 +459,7 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 			for (IJavaSearchScope scope : scopes) {
 				jdtSearch(engine, searchPattern, scope, requestor);
 			}
-			
+
 			return stepDefinitions;
 		} catch (JavaModelException e) {
 			e.printStackTrace();
@@ -465,66 +470,68 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 		}
 	}
 
-	private IJavaSearchScope[] computeScope(SearchEngine searchEngine, IJavaProject javaProject, IProgressMonitor monitor) throws CoreException {
+	private IJavaSearchScope[] computeScope(SearchEngine searchEngine, IJavaProject javaProject,
+			IProgressMonitor monitor) throws CoreException {
 		// TODO improve monitor support
 		List<IJavaSearchScope> scope = new ArrayList<IJavaSearchScope>();
 		if (CucumberJavaPreferences.isUseStepDefinitionsFilters()) {
 			String[] filters = CucumberJavaPreferences.getStepDefinitionsFilters();
 			final List<IJavaElement> pkgScope = new ArrayList<IJavaElement>();
 			final List<IJavaElement> typeScope = new ArrayList<IJavaElement>();
-			
+
 			IJavaSearchScope projectScope = SearchEngine.createJavaSearchScope(new IJavaElement[] { javaProject });
 			SearchRequestor requestor = new SearchRequestor() {
 				@Override
 				public void acceptSearchMatch(SearchMatch match) throws CoreException {
-					if(match.getAccuracy() == SearchMatch.A_ACCURATE) {
-						if(match.getElement() instanceof IPackageFragment) {
+					if (match.getAccuracy() == SearchMatch.A_ACCURATE) {
+						if (match.getElement() instanceof IPackageFragment) {
 							pkgScope.add((IJavaElement) match.getElement());
-						}
-						else if(match.getElement() instanceof IType) {
+						} else if (match.getElement() instanceof IType) {
 							typeScope.add((IJavaElement) match.getElement());
 						}
 					}
 				}
 			};
-			
+
 			for (String filter : filters) {
-				if(filter.endsWith(".*")) {
+				if (filter.endsWith(".*")) {
 					// search for a package
 					String filterWithoutStar = filter.substring(0, filter.length() - 2);
-					SearchPattern searchPattern = SearchPattern.createPattern(filterWithoutStar, IJavaSearchConstants.PACKAGE,
-							IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
-					
-					searchEngine.search(searchPattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, projectScope,
+					SearchPattern searchPattern = SearchPattern.createPattern(filterWithoutStar,
+							IJavaSearchConstants.PACKAGE, IJavaSearchConstants.DECLARATIONS,
+							SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+
+					searchEngine.search(searchPattern,
+							new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, projectScope,
 							requestor, monitor);
-				}
-				else {
+				} else {
 					// search for a type
 					SearchPattern searchPattern = SearchPattern.createPattern(filter, IJavaSearchConstants.TYPE,
-							IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
-					
-					searchEngine.search(searchPattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, projectScope,
+							IJavaSearchConstants.DECLARATIONS,
+							SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+
+					searchEngine.search(searchPattern,
+							new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, projectScope,
 							requestor, monitor);
 				}
 			}
-			if(!pkgScope.isEmpty()) {
+			if (!pkgScope.isEmpty()) {
 				scope.add(SearchEngine.createJavaSearchScope(pkgScope.toArray(new IJavaElement[pkgScope.size()]),
-						IJavaSearchScope.APPLICATION_LIBRARIES));	
+						IJavaSearchScope.APPLICATION_LIBRARIES));
 			}
-			if(!typeScope.isEmpty()) {
+			if (!typeScope.isEmpty()) {
 				scope.add(SearchEngine.createJavaSearchScope(typeScope.toArray(new IJavaElement[typeScope.size()]),
 						IJavaSearchScope.APPLICATION_LIBRARIES));
 			}
-			
-		}
-		else {
+
+		} else {
 			scope.add(SearchEngine.createJavaSearchScope(new IJavaElement[] { javaProject },
 					IJavaSearchScope.APPLICATION_LIBRARIES));
 		}
 		return scope.toArray(new IJavaSearchScope[scope.size()]);
 	}
-	
-	private Set<StepDefinition> getCukeSteps(IMethod method) throws JavaModelException {
+
+	private Set<StepDefinition> getCukeSteps(IMethod method, MarkerFactory markerFactory) throws JavaModelException {
 		Set<StepDefinition> stepDefinitions = new HashSet<StepDefinition>();
 		if (CucumberJavaPreferences.isUseStepDefinitionsFilters()) {
 			String[] filters = CucumberJavaPreferences.getStepDefinitionsFilters();
@@ -534,26 +541,35 @@ public class JavaStepDefinitionsProvider extends AbstractStepDefinitionsProvider
 				return null;
 			}
 		}
-		
+
 		IAnnotation[] annotations = method.getAnnotations();
 		for (IAnnotation annotation : annotations) {
-			CucumberAnnotation cukeAnnotation = getCukeAnnotation(
-					new ArrayList<CucumberAnnotation>(), annotation);
+			CucumberAnnotation cukeAnnotation = getCukeAnnotation(new ArrayList<CucumberAnnotation>(), annotation);
 			if (cukeAnnotation != null) {
-				StepDefinition stepDefinition = new StepDefinition();
-				stepDefinition.setText(getAnnotationText(annotation));
 				IClassFile classFile = method.getClassFile();
 				IJavaElement pkg = classFile.getParent();
 				IJavaElement jar = pkg.getParent();
+				io.cucumber.cucumberexpressions.Expression expression;
+				try {
+					expression = StepDefinition.parseText(cukeAnnotation.getLang(), getAnnotationText(annotation));
+				} catch (CucumberExpressionException e) {
+					if (markerFactory != null) {
+						markerFactory.syntaxErrorOnStepDefinition(jar.getResource(), e, -1);
+						// don't add erronours steps!
+					}
+					continue;
+				}
+
 				String classFileName = classFile.getElementName();
 				String packageName = pkg.getElementName();
 				String jarName = jar.getElementName();
-				stepDefinition.setSourceName(classFileName);
-				stepDefinition.setPackageName(packageName);
-				stepDefinition.setJDTHandleIdentifier(method.getHandleIdentifier());
-				stepDefinition.setLabel(String.format("%s > %s.%s#%s%s", jarName, packageName, classFileName, method.getElementName(), method.getSignature()));
-				stepDefinition.setLang(cukeAnnotation.getLang());
-				stepDefinitions.add(stepDefinition);
+
+				String label = String.format("%s > %s.%s#%s%s", jarName, packageName, classFileName,
+						method.getElementName(), method.getSignature());
+				StepDefinition step = new StepDefinition(method.getHandleIdentifier(), label,
+						expression, jar.getResource(), StepDefinition.NO_LINE_NUMBER, method.getElementName(),
+						packageName);
+				stepDefinitions.add(step);
 			}
 		}
 		return stepDefinitions;


### PR DESCRIPTION
This is a refactoring in preparation of issue #291 it makes the following changes

1. StepDefintion is now a final, unmodifiable class, so it is safe to cache and reference instances of this class
2. StepDefinition now has a ExpresionDefinition (what we will need later to support #291 
3. Serialization was changed, so that the StepDefiniton/ExpresionDefintion must not know how serialization works
4. Error reporting and handling has been improved, so you can recover from broken/old/... serialization files