### PR TITLE
Fix travis build error due to incompatibility between the oraclejdk and ubuntu xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
   - "$HOME/.m2"
 jdk:
-- oraclejdk8
+- openjdk8
 jobs:
   include:
   - stage: Tests


### PR DESCRIPTION
The build [travis#91](https://travis-ci.org/cucumber/cucumber-eclipse/jobs/579786321) failed due to a change of the default Ubuntu distribution from trusty to xenial.
This last have an incompatibility issue with the installation script of the oraclejdk. Thus, the following error occurs during the build:

```
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-07-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
Your build has been stopped.
```

So, I switch the jdk from oraclejdk8 to openjdk8.
This solves the build failure.