### PR TITLE
Fix string highlight in Gherkin files

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/GherkinKeywordScanner.java
@@ -45,8 +45,8 @@ public class GherkinKeywordScanner extends RuleBasedScanner {
 		rules.add(new EndOfLineRule("#", comment)); //$NON-NLS-1$
 
 		// Add rule for strings and character constants.
-		rules.add(new SingleLineRule(" \"", "\" ", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
-		rules.add(new SingleLineRule(" '", "' ", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
+		rules.add(new SingleLineRule("\"", "\"", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
+		rules.add(new SingleLineRule("'", "'", string, '\\')); //$NON-NLS-2$ //$NON-NLS-1$
 
 		// Add rule for tags.
 		rules.add(new GherkinTagRule(tag));


### PR DESCRIPTION
This pull request fixes #378 

![Screenshot from 2019-11-26 13-37-42](https://user-images.githubusercontent.com/6142398/69634367-56551280-1052-11ea-8eff-f240c28fb771.png)

The `GherkinKeywordScanner` class  is responsible of the detection of Gherkin keywords for their highlight. It describes the string object as a token starting by `[space]"` or `[space]'` and ending by `"[space]` or `'[space]`. And so it did not recognize properly the sample describe in #378  
 