### PR TITLE
The steps from scenario outline are not detected 

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
@@ -411,7 +411,7 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 			if (isFound) {
 				Glue glue = glueRepository.add(gherkinStepWrapper, glueStepDefinition);
 				markerFactory.glueFound(glue);
-			} else {
+			} else if(!inScenarioOutline) { // unmatch for the steps with examples will be mark later
 				markerFactory.unmatchedStep(gherkinDocument, gherkinStepWrapper);
 				// if the step was defined before, we need to remove its glue
 				glueRepository.clean(step);
@@ -497,7 +497,6 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 		public void step(Step step) {
 			if (inScenarioOutline) {
 				scenarioOutlineSteps.add(step);
-				return;
 			}
 
 			try {


### PR DESCRIPTION
Fix #382 

As describe in the sample of #382, the steps from a scenario outline are not detected if the examples are not written.
In case of a scenario outline, the step are validated only when parsing the examples, even if the step does not use one of them.

This fix allows to find glue of a step from a scenario outline without reading the example. But in the case of a scenario outline, we ca not mark as `unmatch` if no step definition was found. Indeed, if a example is used, the values can help to match a step definition.



