### PR TITLE
Fix Issue #399 - fix JumpToStepDefinition and StepHyperlinkDetector for multi-project

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
@@ -1,10 +1,12 @@
 package cucumber.eclipse.editor.editors.jumpto;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -29,9 +31,12 @@ class JumpToStepDefinition {
 					.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_JDT_HANDLE_IDENTIFIER_ATTRIBUTE);
 			//Search step in repository
 			if (id != null) {
-				StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
-						.getOrCreate(gherkinFile.getProject(), null);
-				Set<StepDefinition> stepDefinitions = repository.getAllStepDefinitions();
+				Set<StepDefinition> stepDefinitions = new HashSet<>();
+				for (IProject project : gherkinFile.getProject().getWorkspace().getRoot().getProjects()) {
+					StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
+							.getOrCreate(project, null);
+					stepDefinitions.addAll(repository.getAllStepDefinitions());	
+				}
 				for (StepDefinition step : stepDefinitions) {
 					if (id.equals(step.getId())) {
 						return step;

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/JumpToStepDefinition.java
@@ -33,9 +33,15 @@ class JumpToStepDefinition {
 			if (id != null) {
 				Set<StepDefinition> stepDefinitions = new HashSet<>();
 				for (IProject project : gherkinFile.getProject().getWorkspace().getRoot().getProjects()) {
-					StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
-							.getOrCreate(project, null);
-					stepDefinitions.addAll(repository.getAllStepDefinitions());	
+					try {
+						if (project.isOpen()) {
+							StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
+									.getOrCreate(project, null);
+							stepDefinitions.addAll(repository.getAllStepDefinitions());	
+						}
+					} catch (Exception e) {
+						e.printStackTrace();
+					}	
 				}
 				for (StepDefinition step : stepDefinitions) {
 					if (id.equals(step.getId())) {

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
@@ -1,9 +1,11 @@
 package cucumber.eclipse.editor.editors.jumpto;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -59,9 +61,12 @@ public class StepHyperlinkDetector implements IHyperlinkDetector {
 						.getAttribute(MarkerFactory.STEP_DEFINITION_MATCH_JDT_HANDLE_IDENTIFIER_ATTRIBUTE);
 				//Search step in repository
 				if (id != null) {
-					StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
-							.getOrCreate(gherkinFile.getProject(), null);
-					Set<StepDefinition> stepDefinitions = repository.getAllStepDefinitions();
+					Set<StepDefinition> stepDefinitions = new HashSet<>();
+					for (IProject project : gherkinFile.getProject().getWorkspace().getRoot().getProjects()) {
+						StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
+								.getOrCreate(project, null);
+						stepDefinitions.addAll(repository.getAllStepDefinitions());	
+					}
 					for (StepDefinition stepDefinition : stepDefinitions) {
 						if (id.equals(stepDefinition.getId())) {
 							// define the hyperlink region

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/editors/jumpto/StepHyperlinkDetector.java
@@ -63,9 +63,15 @@ public class StepHyperlinkDetector implements IHyperlinkDetector {
 				if (id != null) {
 					Set<StepDefinition> stepDefinitions = new HashSet<>();
 					for (IProject project : gherkinFile.getProject().getWorkspace().getRoot().getProjects()) {
-						StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
-								.getOrCreate(project, null);
-						stepDefinitions.addAll(repository.getAllStepDefinitions());	
+						try {
+							if (project.isOpen()) {
+								StepDefinitionsRepository repository = StepDefinitionsStorage.INSTANCE
+										.getOrCreate(project, null);
+								stepDefinitions.addAll(repository.getAllStepDefinitions());	
+							}
+						} catch (Exception e) {
+							e.printStackTrace();
+						}	
 					}
 					for (StepDefinition stepDefinition : stepDefinitions) {
 						if (id.equals(stepDefinition.getId())) {


### PR DESCRIPTION
when doing the StepHyperlinkDetector and JumpToStepDefinition , expand to fetch from all
projects in the Eclipse workspace, not just the one the gherkin file is from.