### PR TITLE
Add editor preferences for Eclipse's Dark theme

### DIFF
--- a/cucumber.eclipse.editor/META-INF/MANIFEST.MF
+++ b/cucumber.eclipse.editor/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.5.0",
  org.eclipse.equinox.common,
  cucumber.eclipse.steps.jdt,
  org.eclipse.jdt.ui,
- org.eclipse.core.jobs
+ org.eclipse.core.jobs,
+ org.eclipse.e4.ui.css.swt.theme
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: cucumber.eclipse.editor,

--- a/cucumber.eclipse.editor/build.properties
+++ b/cucumber.eclipse.editor/build.properties
@@ -4,5 +4,6 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                icons/,\
-               sample/
+               sample/,\
+               css/
 jars.compile.order = .

--- a/cucumber.eclipse.editor/css/e4_dark_cucumber.css
+++ b/cucumber.eclipse.editor/css/e4_dark_cucumber.css
@@ -1,0 +1,10 @@
+IEclipsePreferences#org-eclipse-ui-workbench:cucumber-eclipse-editor {
+  preferences:
+    'cucumber.eclipse.editor.presentation.gherkin_text_colour=202,202,202'
+    'cucumber.eclipse.editor.presentation.gherkin_comment_colour=196,64,64'
+    'cucumber.eclipse.editor.presentation.gherkin_keyword_colour=196,196,64'
+    'cucumber.eclipse.editor.presentation.gherkin_numeric_literal_colour=64,196,64'
+    'cucumber.eclipse.editor.presentation.gherkin_step_colour=64,196,196'
+    'cucumber.eclipse.editor.presentation.gherkin_string_colour=64,196,64'
+    'cucumber.eclipse.editor.presentation.gherkin_tag_colour=64,196,255';
+}

--- a/cucumber.eclipse.editor/plugin.xml
+++ b/cucumber.eclipse.editor/plugin.xml
@@ -376,4 +376,13 @@
             name="Glue Code Options">
       </page>
    </extension>
+ <extension
+       point="org.eclipse.e4.ui.css.swt.theme">
+    <stylesheet
+          uri="css/e4_dark_cucumber.css">
+       <themeid
+             refid="org.eclipse.e4.ui.css.theme.e4_dark">
+       </themeid>
+    </stylesheet>
+ </extension>
 </plugin>


### PR DESCRIPTION
Fixes #417.

Below are the results with the current set of colours - as you can see, it's now much more readable!
<img width="730" alt="Screenshot 2020-10-09 at 09 34 55" src="https://user-images.githubusercontent.com/10694593/95562418-0be34700-0a14-11eb-819f-05cceb0327f6.png">
