### PR TITLE
Enable Glue Code Options only when selecting a project

### DIFF
--- a/cucumber.eclipse.editor/plugin.xml
+++ b/cucumber.eclipse.editor/plugin.xml
@@ -374,6 +374,9 @@
             class="cucumber.eclipse.editor.properties.ProjectGlueCodeOptions"
             id="cucumber.eclipse.editor.properties.gluecodeoptions"
             name="Glue Code Options">
+         <enabledWhen>
+            <adapt type="org.eclipse.core.resources.IProject"/>
+         </enabledWhen>
       </page>
    </extension>
  <extension


### PR DESCRIPTION
This fixes  #423 by adding a filter to the extension point.