### PR TITLE
[fix/443] Fix Infinite build loop when Step definitions glue detection

### DIFF
--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberGherkinBuilder.java
@@ -115,17 +115,22 @@ public class CucumberGherkinBuilder extends IncrementalProjectBuilder {
 			fullBuildRequired = false;
 			delta.accept(new CucumberGherkinBuildCheckVisitor(glueDetectionEnabled));
 			// the visitor shouldn't do the processing, it blocks user interactions on large jobs
+			boolean featuresHasChanged = false;
 			if (fullBuildRequired) {
 				System.out.println(">gherkin builder: force full build");
 				fullBuild(glueDetectionEnabled, monitor);
+				featuresHasChanged = true;
 			} else {
 				/* no steps changed -> re-build only deltas. */
 				final CucumberGherkinBuildVisitor visitorBuilder = new CucumberGherkinBuildVisitor(markerFactory, resources, glueDetectionEnabled, monitor);
 				delta.accept(visitorBuilder);
+				featuresHasChanged = !resources.isEmpty();
 				/* Perform linking with any gherkin resources found. */
 				build(visitorBuilder, glueDetectionEnabled, monitor);
 			}
-			glueStorage.persist(getProject(), monitor);
+			if(featuresHasChanged) {
+				glueStorage.persist(getProject(), monitor);
+			}
 		} catch (CoreException e) {
 			throw new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, e.getMessage(), e));
 		}

--- a/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberStepDefinitionsBuilder.java
+++ b/cucumber.eclipse.editor/src/main/java/cucumber/eclipse/editor/builder/CucumberStepDefinitionsBuilder.java
@@ -90,8 +90,11 @@ public class CucumberStepDefinitionsBuilder extends IncrementalProjectBuilder {
 				stepDefinitionsProvider.load(project);
 			}
 			// the visitor does the work.
-			delta.accept(new CucumberStepDefinitionsBuildVisitor(markerFactory, monitor));
-			stepDefinitionsProvider.persist(getProject(), monitor);
+			CucumberStepDefinitionsBuildVisitor visitor = new CucumberStepDefinitionsBuildVisitor(markerFactory, monitor);
+			delta.accept(visitor);
+			if(visitor.hasProcessedAtLeastOneFile()) {
+				stepDefinitionsProvider.persist(getProject(), monitor);
+			}
 		} catch (CoreException e) {
 			e.printStackTrace();
 		} catch (IOException e) {
@@ -104,6 +107,7 @@ public class CucumberStepDefinitionsBuilder extends IncrementalProjectBuilder {
 
 		private IProgressMonitor monitor;
 		private MarkerFactory markerFactory;
+		private boolean hasProcessedAtLeastOneFile = false;
 
 		public CucumberStepDefinitionsBuildVisitor(MarkerFactory markerFactory, IProgressMonitor monitor) {
 			this.monitor = monitor;
@@ -126,6 +130,7 @@ public class CucumberStepDefinitionsBuilder extends IncrementalProjectBuilder {
 				return true;
 			}
 			if(stepDefinitionsProvider.support(resource)) {
+				this.hasProcessedAtLeastOneFile = true;
 				this.markerFactory.cleanMarkers(resource);
 				stepDefinitionsProvider.findStepDefinitions(resource, markerFactory, monitor);
 			}
@@ -155,6 +160,13 @@ public class CucumberStepDefinitionsBuilder extends IncrementalProjectBuilder {
 			}
 			
 			return true;
+		}
+		
+		/**
+		 * @return true if at least one file has be really processed by this visitor.
+		 */
+		public boolean hasProcessedAtLeastOneFile() {
+			return this.hasProcessedAtLeastOneFile;
 		}
 
 	}


### PR DESCRIPTION
Fixes #443 Fix Infinite build loop when Step definitions glue detection

Prevent the update of cucumber.glue.tmp and cucumber.stepDefinitions.tmp when the .feature and steps files have not been modified.