### PR TITLE
Make all commands use the same Cucumber category

### DIFF
--- a/cucumber.eclipse.editor/plugin.xml
+++ b/cucumber.eclipse.editor/plugin.xml
@@ -64,39 +64,6 @@
         </colorDefinition>
      </extension>
    <extension
-         point="org.eclipse.ui.commands">
-      <category
-            name="Formatter"
-            id="cucumber.eclipse.editor.formmtter">
-      </category>
-      <category 
-            name="findstep"
-            id="cucumber.eclipse.editor.find">
-      </category>     
-      <command
-            categoryId="cucumber.eclipse.editor.formmtter"
-            description="Format"
-            id="cucumber.eclipse.editor.formmater.pretty_formatter"
-            name="Pretty format feature file">
-      </command>
-      <command
-            categoryId="cucumber.eclipse.editor.find"
-            description="Find step"
-            id="cucumber.eclipse.editor.navigation.findstep"
-            name="Find step">
-      </command>
-      <command
-            description="Toggle comment"
-            id="cucumber.eclipse.editor.toggle.comment"
-            name="Toggle comment">
-      </command>
-      <command
-            description="Recalculate"
-            id="cucumber.eclipse.editor.toggle.recalculate"
-            name="Recalculate steps">      		
-      </command>
-   </extension>
-   <extension
          point="org.eclipse.ui.handlers">
       <handler
             commandId="cucumber.eclipse.editor.formmater.pretty_formatter"
@@ -327,6 +294,30 @@
          categoryId="cucumber.eclipse.category"
          id="cucumber.eclipse.commands.addNatureCommand"
          name="Convert to Cucumber Project...">
+   </command>
+   <command
+         categoryId="cucumber.eclipse.category"
+         description="Format"
+         id="cucumber.eclipse.editor.formmater.pretty_formatter"
+         name="Pretty format feature file">
+   </command>
+   <command
+         categoryId="cucumber.eclipse.category"
+         description="Find step"
+         id="cucumber.eclipse.editor.navigation.findstep"
+         name="Find step">
+   </command>
+   <command
+         categoryId="cucumber.eclipse.category"
+         description="Toggle comment"
+         id="cucumber.eclipse.editor.toggle.comment"
+         name="Toggle comment">
+   </command>
+   <command
+         categoryId="cucumber.eclipse.category"
+         description="Recalculate"
+         id="cucumber.eclipse.editor.toggle.recalculate"
+         name="Recalculate steps">      		
    </command>
 </extension>
 <extension


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

All commands were grouped together and are all associated with the `cucumber.eclipse.category` category.

# Motivation & context

Fixes #380.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Now all commands appear and can be changed easily:
![cucumber-fixed](https://user-images.githubusercontent.com/10694593/139123794-cbc67340-876c-4892-b884-f80da05dfb77.png)


# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
