### PR TITLE
Add support for validation plugins from the project

### DIFF
--- a/examples/java-datatable/src/main/java/cucumber/examples/datatable/AnimalValidator.java
+++ b/examples/java-datatable/src/main/java/cucumber/examples/datatable/AnimalValidator.java
@@ -1,0 +1,78 @@
+package cucumber.examples.datatable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.cucumber.core.gherkin.DataTableArgument;
+import io.cucumber.plugin.ConcurrentEventListener;
+import io.cucumber.plugin.Plugin;
+import io.cucumber.plugin.event.EventPublisher;
+import io.cucumber.plugin.event.PickleStepTestStep;
+import io.cucumber.plugin.event.Step;
+import io.cucumber.plugin.event.StepArgument;
+import io.cucumber.plugin.event.TestStep;
+import io.cucumber.plugin.event.TestStepFinished;
+
+/**
+ * This validator is enabled in the feature by using
+ * <code>#validation-plugin: cucumber.examples.datatable.AnimalValidator</code>
+ */
+public class AnimalValidator implements Plugin, ConcurrentEventListener {
+
+	private ConcurrentHashMap<Integer, String> errors = new ConcurrentHashMap<>();
+
+	@Override
+	public void setEventPublisher(EventPublisher publisher) {
+		publisher.registerHandlerFor(TestStepFinished.class, this::handleTestStepFinished);
+	}
+
+	private void handleTestStepFinished(TestStepFinished event) {
+		TestStep testStep = event.getTestStep();
+		if (testStep instanceof PickleStepTestStep) {
+			PickleStepTestStep pickleStepTestStep = (PickleStepTestStep) testStep;
+			Step step = pickleStepTestStep.getStep();
+			if ("the animal {string}".equals(pickleStepTestStep.getPattern())) {
+				StepArgument argument = step.getArgument();
+				Animals animal = loadAnimal(pickleStepTestStep.getDefinitionArgument().get(0).getValue());
+				if (animal == null) {
+					// Invalid animal!
+					return;
+				}
+				if (argument instanceof DataTableArgument dataTable) {
+					List<String> availableData = animal.getAvailableData();
+					List<List<String>> cells = dataTable.cells();
+					for (int i = 1; i < cells.size(); i++) {
+						int line = dataTable.getLine() + i;
+						List<String> list = cells.get(i);
+						String vv = list.get(0);
+						if (!animal.getAvailableDataForAnimals().contains(vv)) {
+							errors.put(line, vv + " is not valid for any animal");
+						} else if (!availableData.contains(vv)) {
+							errors.put(line, vv + " is not valid for animal " + animal.getClass().getSimpleName());
+						}
+					}
+				}
+			}
+		}
+	}
+	//This is a magic method called by cucumber-eclipse to fetch the final errors and display them in the document
+	public Map<Integer, String> getValidationErrors() {
+		return errors;
+	}
+
+	private Animals loadAnimal(String value) {
+		try {
+			Class<?> clz = getClass().getClassLoader()
+					.loadClass("cucumber.examples.datatable." + value.replace("\"", ""));
+			Object instance = clz.getConstructor().newInstance();
+			if (instance instanceof Animals anml) {
+				return anml;
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+}

--- a/examples/java-datatable/src/test/resources/cucumber/examples/datatable.feature
+++ b/examples/java-datatable/src/test/resources/cucumber/examples/datatable.feature
@@ -1,4 +1,6 @@
 #language: en
+#This comment below enables the validation plugin
+#validation-plugin: cucumber.examples.datatable.AnimalValidator
 Feature: Connection between DataTable Key and a specific Step Value
 
 

--- a/io.cucumber.eclipse.editor/plugin.xml
+++ b/io.cucumber.eclipse.editor/plugin.xml
@@ -110,6 +110,14 @@
 	  	<attribute name="cucumber.eclipse.marker.gherkin.unmatched_step.path"/>
 	  	<persistent value="true"/>
 	</extension>
+    <extension
+	    id="cucumber.eclipse.marker.gherkin.validation_error"
+	    name="Step Validation Error"
+	    point="org.eclipse.core.resources.markers">
+	    <super type="org.eclipse.core.resources.problemmarker"/>
+	  	<super type="cucumber.eclipse.marker"/>
+	  	<persistent value="true"/>
+	</extension>
 	<extension
          point="org.eclipse.ui.editors.markerAnnotationSpecification">
       <specification

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/marker/MarkerFactory.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/marker/MarkerFactory.java
@@ -36,6 +36,8 @@ public class MarkerFactory {
 
 	public static final String CUCUMBER_MARKER = "cucumber.eclipse.marker";
 	public static final String STEPDEF_SYNTAX_ERROR = CUCUMBER_MARKER + ".stepdef.syntaxerror";
+	public static final String STEPDEF_VALIDATION_ERROR = CUCUMBER_MARKER + ".gherkin.validation_error";
+
 	public static final String GHERKIN_SYNTAX_ERROR = CUCUMBER_MARKER + ".gherkin.syntaxerror";
 
 	public static final String STEP_DEFINTION_MATCH = CUCUMBER_MARKER + ".stepdef.matches";
@@ -61,6 +63,31 @@ public class MarkerFactory {
 	public static final String CUCUMBER_NATURE_MISSING_MARKER = CUCUMBER_MARKER + ".project.cucumber_nature_missing";
 
 	private MarkerFactory() {
+	}
+
+	public static void validationErrorOnStepDefinition(final IResource resource,
+			Map<Integer, String> errors, boolean persistent) {
+		if (errors == null || errors.isEmpty()) {
+			return;
+		}
+
+		mark(resource, new IMarkerBuilder() {
+			@Override
+			public void build() throws CoreException {
+				IMarker[] markers = resource.findMarkers(STEPDEF_VALIDATION_ERROR, true, IResource.DEPTH_INFINITE);
+				for (IMarker marker : markers) {
+					marker.delete();
+				}
+				for (Entry<Integer, String> entry : errors.entrySet()) {
+					IMarker marker = resource.createMarker(STEPDEF_VALIDATION_ERROR);
+					marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+					marker.setAttribute(IMarker.MESSAGE, entry.getValue());
+					marker.setAttribute(IMarker.LINE_NUMBER, entry.getKey());
+					marker.setAttribute(IMarker.TRANSIENT, persistent);
+				}
+			}
+		});
+
 	}
 
 	public void syntaxErrorOnStepDefinition(IResource stepDefinitionResource, Exception e) {

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/runtime/CucumberRuntime.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/runtime/CucumberRuntime.java
@@ -150,6 +150,23 @@ public final class CucumberRuntime implements AutoCloseable {
 		plugins.add(plugin);
 	}
 
+	public Plugin addPluginFromClasspath(String clazz) {
+		try {
+			Class<?> c = classLoader.loadClass(clazz);
+			Object instance = c.getConstructor().newInstance();
+			if (instance instanceof Plugin) {
+				Plugin plugin = (Plugin) instance;
+				addPlugin(plugin);
+				return plugin;
+			}
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return null;
+//		plugins.add(plugin);
+	}
+
 	public void addFeature(GherkinEditorDocument document) {
 		IResource resource = document.getResource();
 		URI uri = Objects.requireNonNullElseGet(resource.getLocationURI(), () -> resource.getRawLocationURI());


### PR DESCRIPTION
Currently it is only possible to validate the glue on execution but it some cases it would be useful to have some prevalidation.

This adds support for specify validation plugins in the glue code that are executed as part of the parsing of document and show up as errors immediately on save.

# Demo
https://github.com/cucumber/cucumber-eclipse/assets/1331477/bf94219f-b131-4c56-9600-7f7db052cab9

