### PR TITLE
Create individual FUNDING.yml file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+open_collective: cucumber
+github: cucumber,laeubi


### PR DESCRIPTION
I know this project is a bit outside the usual view-port of usual cucumber committers and mostly overhauled and maintained by me since more than five years now see:

https://github.com/cucumber/cucumber-eclipse/graphs/contributors?from=1.1.2019

@davidjgoss @aslakhellesoy @mpkorstanje would you be fine to extend the organization file with my username for sponsoring? It will still show the usual links as before just with an additional one to my profile then.
