### PR TITLE
Fix wrong CucumberJavaBackendProperties#setEnabled method

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dtycho-version=4.0.11
+-Dtycho-version=4.0.13

--- a/io.cucumber.eclipse.java/META-INF/MANIFEST.MF
+++ b/io.cucumber.eclipse.java/META-INF/MANIFEST.MF
@@ -3,6 +3,16 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Java
 Bundle-SymbolicName: io.cucumber.eclipse.java;singleton:=true
 Bundle-Version: 3.0.0.qualifier
+Export-Package: io.cucumber.eclipse.java;x-internal:=true,
+ io.cucumber.eclipse.java.codemining;x-internal:=true,
+ io.cucumber.eclipse.java.launching;x-internal:=true,
+ io.cucumber.eclipse.java.plugins;x-internal:=true,
+ io.cucumber.eclipse.java.preferences;x-internal:=true,
+ io.cucumber.eclipse.java.properties;x-internal:=true,
+ io.cucumber.eclipse.java.quickfix;x-internal:=true,
+ io.cucumber.eclipse.java.runtime;x-internal:=true,
+ io.cucumber.eclipse.java.steps;x-internal:=true,
+ io.cucumber.eclipse.java.validation;x-internal:=true
 Bundle-Activator: io.cucumber.eclipse.java.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/properties/CucumberJavaBackendProperties.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/properties/CucumberJavaBackendProperties.java
@@ -39,7 +39,7 @@ public final record CucumberJavaBackendProperties(IEclipsePreferences node) {
 		if (node == null) {
 			return;
 		}
-		node.getBoolean(KEY_ENABLE_PROJECT_SPECIFIC_SETTINGS, false);
+		node.putBoolean(KEY_ENABLE_PROJECT_SPECIFIC_SETTINGS, enabled);
 	}
 
 	public void flush() {


### PR DESCRIPTION
CucumberJavaBackendProperties#setEnabled does not do what it claims and instead of just fetches the current value as a result of C&P error.

This now fixes the method to correctly update the value, beside that it exports all packages (as internal) to allow access for other plugins that want to change java settings programmatically.
