### PR TITLE
Allow to externally trigger validation of Gluecodes

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Dtycho-version=4.0.13
+-Dtycho.localArtifacts=ignore


### PR DESCRIPTION
Currently the GlueCode is only validated when open an editor. To allow extension plugins to perform the validation beforehand, this now adds a new method to allow triggering the validation for editors not currently open as well.
