### PR TITLE
Setup a workflow to automatically discover updates in target-platform

### DIFF
--- a/.github/updateTarget.yml
+++ b/.github/updateTarget.yml
@@ -1,0 +1,25 @@
+name: Target Platform Updates
+
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.target'
+
+
+jobs:
+  update:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/updateTarget.yml@master
+    with:
+      author: cukebot <cukebot@cucumber.io>
+      path: 'io.cucumber.eclipse.targetdefinition'
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,28 @@
 				</executions>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho.extras</groupId>
+					<artifactId>tycho-version-bump-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<executions>
+						<execution>
+							<id>update-target</id>
+							<configuration>
+								<updateEmptyVersion>false</updateEmptyVersion>
+								<allowMajorUpdates>false</allowMajorUpdates>
+<!--								<mavenRulesUri>${project.basedir}/update-rules.xml</mavenRulesUri>-->
+								<updateSiteDiscovery>
+									<strategy>datePattern</strategy>
+								</updateSiteDiscovery>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 	<profiles>
 		<profile>


### PR DESCRIPTION
Currently the target platform is updates manually (and developers need to be aware of updates).

This now adds a new automated workflow that checks regularly for updates and creates a PR to make developers aware of it.

As renovate currently does not support it:
- https://github.com/renovatebot/renovate/issues/37539