### PR TITLE
Automatically upgrade dependencies in target files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>cucumber/renovate-config"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/.*\\.target$/"
+      ],
+      "matchStrings": [
+        "<groupId>(?<groupId>.*?)<\\/groupId>\\s*<artifactId>(?<artifactId>.*?)<\\/artifactId>\\s*<version>(?<currentValue>.*?)<\\/version>"
+      ],
+      "datasourceTemplate": "maven",
+      "versioningTemplate": "maven",
+      "packageNameTemplate": "{{{groupId}}}:{{{artifactId}}}"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>cucumber/renovate-config"
-  ]
-}


### PR DESCRIPTION
### 🤔 What's changed?

Configured Renovate to update `*.target` files and move the renovate config to the `.github` folder to reduce clutter in the root of the project. The effects can be seen on the dashboard here: https://github.com/mpkorstanje/cucumber-eclipse/issues/3

<img width="824" height="1051" alt="Screenshot From 2025-09-29 16-45-16" src="https://github.com/user-attachments/assets/3c4f7ed8-6e23-47ad-a46f-8be638974f31" />



### ⚡️ What's your motivation? 

Improve on https://github.com/cucumber/cucumber-eclipse/pull/550 by avoiding the need for workflows to have access to tokens.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Renovate is currently configured to [automatically merge minor updates](https://github.com/cucumber/renovate-config/blob/2feae28551032a5913579c9076baaf32c476e7b4/default.json#L8).

This reduces the need for maintainer interaction, but because this repo also does automatically make releases from every commit on main there is a potentially toxic combination of permissions where updates are released without having been looked at.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
