### PR TITLE
Update to Gherkin with native OSGi metadata

### DIFF
--- a/io.cucumber.eclipse.targetdefinition/cucumber.eclipse.targetdefinition.target
+++ b/io.cucumber.eclipse.targetdefinition/cucumber.eclipse.targetdefinition.target
@@ -12,23 +12,15 @@
 		<repository location="https://download.eclipse.org/technology/m2e/releases/latest/"/>
 		<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="0.0.0"/>
 	</location>
-	<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+	<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
 		<dependencies>
 			<dependency>
 				<groupId>io.cucumber</groupId>
 				<artifactId>gherkin</artifactId>
-				<version>36.0.0</version>
+				<version>36.1.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
-		<instructions><![CDATA[
-Bundle-Name:           ${mvnGroupId}:${mvnArtifactId}:${mvnVersion}
-version:               ${version_cleanup;${mvnVersion}}
-Bundle-SymbolicName:   ${mvnGroupId}.${mvnArtifactId}
-Bundle-Version:        ${version}
-Import-Package:        !sun.*,io.cucumber.messages.internal.com.google.gson*,!io.cucumber.messages.internal.*,!org.checkerframework.*,*
-Export-Package:        *;version="${version}";-noimport:=true
-]]></instructions>
 	</location>
 	<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 		<dependencies>


### PR DESCRIPTION
Gherkin now is shipped with first-class OSGi metadata see

- https://github.com/cucumber/gherkin/pull/485

so we no longer need to wrap it

<img width="936" height="727" alt="grafik" src="https://github.com/user-attachments/assets/76521791-bc42-4ca5-b709-b0fa18dac54f" />

This also transitively includes cucumber messages with OSGi metadata see:

- https://github.com/cucumber/messages/pull/344


Many thanks @mpkorstanje for the release :-)