### PR TITLE
Remove the stCarolas/setup-maven

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,10 +28,6 @@ jobs:
         distribution: 'adopt'
         architecture: 'x64'
         cache: maven
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
-      with:
-        maven-version: 3.9.9
     - name: Build with Maven
       working-directory: code
       run: mvn -B package --file pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ io.cucumber.eclipse.lsp/
 cucumber.*/
 .polyglot*
 .tycho*
+.idea/


### PR DESCRIPTION
### ⚡️ What's your motivation? 

The ubuntu-latest image includes Maven 3.9.14[1]. This makes a separate setup action redundant.

1. https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#project-management

### 🏷️ What kind of change is this?
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
