### PR TITLE
Split build process into test and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,13 +20,14 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: code
-        # Credentials are needed to push GitHub pages.
-        persist-credentials: true
+        persist-credentials: false
     - name: Checkout pages
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: gh-pages
         ref: gh-pages
+        # Credentials are needed to push GitHub pages.
+        persist-credentials: true
     - name: Set up JDK
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,45 +1,49 @@
-name: cucumber-eclipse plugin (latest)
+name: deploy cucumber-eclipse plugin (latest)
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: deploy-cucumber-eclipse-plugin
 
 jobs:
   build:
-
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: code
+        # Credentials are needed to push GitHub pages.
+        persist-credentials: true
     - name: Checkout pages
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: gh-pages
         ref: gh-pages
-      if: github.event_name != 'pull_request'
     - name: Set up JDK
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: '21'
         distribution: 'adopt'
         architecture: 'x64'
-        cache: maven
     - name: Build with Maven
       working-directory: code
-      run: mvn -B package --file pom.xml
-    - name: deploy
+      run: mvn --batch-mode package
+    - name: Deploy to GitHub Pages
       working-directory: gh-pages
       run: |
+        rm -rf update-site/${GITHUB_REF##*/}/
         mkdir -p update-site/${GITHUB_REF##*/}/
         cp -R ../code/io.cucumber.eclipse.updatesite/target/repository/* update-site/${GITHUB_REF##*/}/
         git add .
         git config user.name github-actions
         git config user.email github-actions@github.com
         git commit -m "Add latest update-site for version ${GITHUB_REF##*/}"
-        git push origin gh-pages --force
-      if: github.event_name != 'pull_request'
-
+        git push origin gh-pages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: test cucumber-eclipse plugin
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        java-version: '21'
+        distribution: 'adopt'
+        architecture: 'x64'
+        cache: maven
+    - name: Build with Maven
+      run: mvn --batch-mode package


### PR DESCRIPTION
### ⚡️ What's your motivation? 

The default GitHub Actions have all permissions. This has been reduced at the Cucumber org level to reading repository contents and published packages. As a consequence the build would fail because it is not allowed to push to the GitHub pages branch.

This can be fixed by explicitly declaring the permissions.

Additionally, the actions/setup-java action uses a cache when making deployments. This provides an avenue that can potentially be exploited. See: https://docs.zizmor.sh/audits/#artipacked

By splitting the deployment and tests in to separate actions we can assign each the exact permissions needed while  still enabling caching for pull requests. This does result in some duplication, but that seems okay to me.


### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
