### PR TITLE
Add provenance of release to commit message

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,5 +45,6 @@ jobs:
         git add .
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git commit -m "Add latest update-site for version ${GITHUB_REF##*/}"
+        git commit -F - <<EOF 
+        Add latest update-site for version ${GITHUB_REF##*/}" -m "Created from ${{ github.sha }}"
         git push origin gh-pages


### PR DESCRIPTION
### ⚡️ What's your motivation? 
This makes it easier to find which commit on `main` created which commit in the `gh-pages` branch.>

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
