### PR TITLE
Update to Tycho 5.0.3

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,2 @@
--Dtycho-version=5.0.0
+-Dtycho-version=5.0.3
 -Dtycho.localArtifacts=ignore


### PR DESCRIPTION
@mpkorstanje it seems renovate is not detecting versions defined in `maven.config` directly do you think we can have a manual rule somehow? 

Basically one would look here: https://central.sonatype.com/artifact/org.eclipse.tycho/tycho-build/ for the latest version and then replace the `tycho-version` in the file `.mvn/maven.config`