### PR TITLE
perf: improve tracing for glue validation pipeline

### DIFF
--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -138,8 +138,29 @@ If you are not sure which part is slow, enable the plugin's built-in performance
 
 | Option | What is measured |
 | -------| ---------------- |
-| `perf` | Overall validation timing per document |
-| `perf/steps` | Per-step timing during step-definition matching |
+| `perf` | Validation job start/end, document counts, revalidation trigger counts, builder stats |
+| `perf/steps` | Per-phase timing inside glue validation: classloader creation, feature parsing, Cucumber runtime execution (glue load + step matching), JDT type resolution for content assist |
+
+**Sample output with `perf/steps=true`** (what to look for):
+
+```
+CucumberRuntime created for 'my-project' with 342 classpath URL(s)
+[my-project] Classloader created in 1843ms
+[my-project] Parsed 12/12 feature(s) in 28ms
+[my-project] Runtime (glue load + match) took 3210ms for 12 feature(s), glue filters: []
+  login.feature: 8/47 steps matched, 0 missing
+  checkout.feature: 12/47 steps matched, 0 missing
+[my-project] Total glue validation: 5124ms (12 doc(s), 47 step def(s))
+findStepDefinitions: resolving 47 step def(s) via JDT for checkout.feature
+findStepDefinitions: resolved 47/47 in 612ms
+```
+
+**How to interpret the numbers:**
+
+- A high **Classloader created** time (> 500ms) and a large classpath URL count (> 200) means classloader caching (planned improvement) will help significantly.
+- A high **Runtime (glue load + match)** time with empty `glue filters: []` means adding glue path filters (Option 1) will directly reduce that time.
+- A high **findStepDefinitions** time means content-assist JDT type resolution is slow; this will be addressed by caching (planned improvement).
+- If **Parsed N/N feature(s)** shows many features being parsed each time, limiting the revalidation scope to open editors (planned improvement) will reduce that count.
 
 Additional debug options (useful when investigating unexpected behaviour, not just performance):
 
@@ -156,14 +177,19 @@ Additional debug options (useful when investigating unexpected behaviour, not ju
 Look for lines like:
 
 ```
-Total validation time for 12 document(s): 4823ms
+Verify Features: starting validation of 85 document(s)
+revalidateDocuments(my-project): 2 editor doc(s), 83 background doc(s) scheduled
+[my-project] Classloader created in 1843ms
+[my-project] Runtime (glue load + match) took 3210ms for 85 feature(s), glue filters: []
+[my-project] Total glue validation: 5124ms (85 doc(s), 47 step def(s))
+Verify Features: finished in 5202ms (85/85 syntax-valid)
 ```
 
-A high number here with a small document count means glue scanning (classpath loading) dominates.
-In that case, **Option 1** (glue path filters) will have the most impact.
+The **revalidateDocuments** line is the most diagnostic: it shows how many documents are queued each time a glue change is detected.
+A high background doc count (like 83 in the example above) means many feature files are being revalidated unnecessarily — this is the core problem that incremental improvements address.
 
-If the per-document time is low but many documents are validated at once, the total time is dominated by breadth.
-In that case, **Option 2** (disabling the builder or reducing tracked files) helps most.
+A high **Classloader created** time combined with a large classpath URL count is the next bottleneck.
+A high **Runtime** time with `glue filters: []` means adding glue path filters (Option 1) will directly reduce that time.
 
 ---
 

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/builder/CucumberFeatureBuilder.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/builder/CucumberFeatureBuilder.java
@@ -14,6 +14,7 @@ import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import io.cucumber.eclipse.editor.ResourceHelper;
+import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocument;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocumentManager;
 import io.cucumber.eclipse.editor.validation.BatchUpdater;
@@ -44,11 +45,26 @@ public class CucumberFeatureBuilder extends IncrementalProjectBuilder {
 	@Override
 	protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
 		IProject project = getProject();
+		boolean perf = Tracing.PERF;
+		long start = perf ? System.currentTimeMillis() : 0;
+		String kindName = switch (kind) {
+			case FULL_BUILD -> "FULL";
+			case INCREMENTAL_BUILD -> "INCREMENTAL";
+			case AUTO_BUILD -> "AUTO";
+			case CLEAN_BUILD -> "CLEAN";
+			default -> "UNKNOWN(" + kind + ")";
+		};
+
 		try (BatchUpdater batch = DocumentValidator.batch()) {
 			Set<GherkinEditorDocument> documents = new LinkedHashSet<>();
 			
 			// Collect all feature files (excluding derived resources like target/bin)
 			Set<IFile> featureFiles = ResourceHelper.getFeatureFilesInProject(project);
+
+			if (perf) {
+				Tracing.get().trace(Tracing.PERFORMANCE, "CucumberFeatureBuilder [" + kindName + "] "
+						+ project.getName() + ": " + featureFiles.size() + " feature file(s) found");
+			}
 			
 			// Create tracked documents for validation
 			for (IFile file : featureFiles) {
@@ -69,6 +85,11 @@ public class CucumberFeatureBuilder extends IncrementalProjectBuilder {
 			}
 		} catch (Exception e) {
 			ILog.get().error("Failed to validate project: " + project.getName(), e);
+		}
+
+		if (perf) {
+			Tracing.get().trace(Tracing.PERFORMANCE, "CucumberFeatureBuilder [" + kindName + "] "
+					+ project.getName() + ": done in " + (System.currentTimeMillis() - start) + "ms");
 		}
 		return null;
 	}

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/validation/DocumentValidator.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/validation/DocumentValidator.java
@@ -1,6 +1,7 @@
 package io.cucumber.eclipse.editor.validation;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -15,6 +16,7 @@ import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.text.IDocument;
 
+import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocumentManager;
 import io.cucumber.eclipse.editor.document.IGherkinDocumentListener;
 import io.cucumber.eclipse.editor.preferences.CucumberEditorPreferences;
@@ -233,26 +235,40 @@ public class DocumentValidator implements IGherkinDocumentListener {
 	 * @param project the project whose documents should be revalidated
 	 */
 	public static void revalidateDocuments(IProject project) {
+		int editorCount = 0;
+		int resourceCount = 0;
 		Set<IResource> scheduled = new HashSet<>();
-		textBufferDocuments.forEach((doc, job) -> {
+		for (Map.Entry<IDocument, VerificationJob> e : textBufferDocuments.entrySet()) {
+			IDocument doc = e.getKey();
+			VerificationJob job = e.getValue();
 			IResource resource = GherkinEditorDocumentManager.resourceForDocument(doc);
 			if (resource == null || resource.getProject() != project) {
-				return;
+				continue;
 			}
 			if (INSTANCE.addToBatch(doc)) {
-				return;
+				editorCount++;
+				continue;
 			}
 			scheduleValidation(resource, job);
-		});
-		resourceDocuments.forEach((resource, job) -> {
-
+			scheduled.add(resource);
+			editorCount++;
+		}
+		for (Map.Entry<IResource, VerificationJob> e : resourceDocuments.entrySet()) {
+			IResource resource = e.getKey();
+			VerificationJob job = e.getValue();
 			if (resource.getProject() == project && scheduled.add(resource)) {
 				if (INSTANCE.addToBatch(resource)) {
-					return;
+					resourceCount++;
+					continue;
 				}
 				scheduleValidation(resource, job);
+				resourceCount++;
 			}
-		});
+		}
+		if (Tracing.PERF) {
+			Tracing.get().trace(Tracing.PERFORMANCE, "revalidateDocuments(" + project.getName() + "): "
+					+ editorCount + " editor doc(s), " + resourceCount + " background doc(s) scheduled");
+		}
 	}
 
 	/**

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/validation/VerificationJob.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/validation/VerificationJob.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.jobs.Job;
 
 import io.cucumber.eclipse.editor.CucumberServiceRegistry;
 import io.cucumber.eclipse.editor.EditorLogging;
+import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocument;
 import io.cucumber.eclipse.editor.marker.MarkerFactory;
 import io.cucumber.messages.types.ParseError;
@@ -67,6 +68,13 @@ abstract class VerificationJob extends Job {
 			return Status.OK_STATUS;
 		}
 
+		boolean perf = Tracing.PERF;
+		long start = perf ? System.currentTimeMillis() : 0;
+		if (perf) {
+			Tracing.get().trace(Tracing.PERFORMANCE, getName() + ": starting validation of "
+					+ editorDocuments.size() + " document(s)");
+		}
+
 		// Stage 1: Syntax validation
 		List<GherkinEditorDocument> validDocuments = validateSyntax(editorDocuments, monitor);
 		if (monitor.isCanceled()) {
@@ -75,6 +83,12 @@ abstract class VerificationJob extends Job {
 
 		// Stage 2: Glue validation
 		validateGlue(validDocuments, monitor);
+
+		if (perf) {
+			Tracing.get().trace(Tracing.PERFORMANCE, getName() + ": finished in "
+					+ (System.currentTimeMillis() - start) + "ms"
+					+ " (" + validDocuments.size() + "/" + editorDocuments.size() + " syntax-valid)");
+		}
 
 		return monitor.isCanceled() ? Status.CANCEL_STATUS : Status.OK_STATUS;
 	}

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/runtime/CucumberRuntime.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/runtime/CucumberRuntime.java
@@ -33,6 +33,7 @@ import io.cucumber.core.runtime.Runtime;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.core.snippets.SnippetType;
 import io.cucumber.eclipse.editor.EditorLogging;
+import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocument;
 import io.cucumber.eclipse.java.JDTUtil;
 import io.cucumber.eclipse.java.launching.FileResource;
@@ -175,9 +176,15 @@ public final class CucumberRuntime implements AutoCloseable {
 	}
 
 	public static CucumberRuntime create(IJavaProject javaProject) throws CoreException {
-		// TODO can we cache the classlaoder here to optimize performance? As long as
-		// the classpath do not change there won't be any new classes be loaded...
-		return new CucumberRuntime(javaProject);
+		// TODO can we cache the classloader here to optimize performance? As long as
+		// the classpath does not change there won't be any new classes be loaded...
+		CucumberRuntime rt = new CucumberRuntime(javaProject);
+		if (Tracing.PERF_STEPS) {
+			Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "CucumberRuntime created for '"
+					+ javaProject.getElementName() + "' with "
+					+ rt.classLoader.getURLs().length + " classpath URL(s)");
+		}
+		return rt;
 	}
 
 	public void setGenerator(UuidGenerator uuidGenerator) {

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 import io.cucumber.eclipse.editor.steps.ExpressionDefinition;
 import io.cucumber.eclipse.editor.steps.IStepDefinitionsProvider;
 import io.cucumber.eclipse.editor.steps.StepDefinition;
+import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.java.JDTUtil;
 import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 import io.cucumber.eclipse.java.plugins.CucumberStepDefinition;
@@ -55,11 +56,25 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 			IJavaProject javaProject = JDTUtil.getJavaProject(resource);
 			SubMonitor subMonitor = SubMonitor.convert(monitor, "Searching Java Glue Code steps", 200);
 			Collection<CucumberStepDefinition> steps = javaValidator.getAvailableSteps(viewer.getDocument());
+
+			boolean perf = Tracing.PERF_STEPS;
+			long start = perf ? System.currentTimeMillis() : 0;
+			if (perf) {
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "findStepDefinitions: resolving "
+						+ steps.size() + " step def(s) via JDT for " + resource.getName());
+			}
+
 			SubMonitor remaining = subMonitor.setWorkRemaining(steps.size());
 			Map<String, IType> typeBuffer = new ConcurrentHashMap<>();
-			return steps.parallelStream()
+			Collection<StepDefinition> result = steps.parallelStream()
 					.map(cucumberStep -> parseStepDefintion(cucumberStep, javaProject, typeBuffer, remaining.split(1)))
 					.filter(Objects::nonNull).collect(Collectors.toList());
+
+			if (perf) {
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "findStepDefinitions: resolved "
+						+ result.size() + "/" + steps.size() + " in " + (System.currentTimeMillis() - start) + "ms");
+			}
+			return result;
 		} catch (OperationCanceledException e) {
 		}
 		return Collections.emptyList();

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/validation/JavaGlueJob.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/validation/JavaGlueJob.java
@@ -17,7 +17,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.osgi.service.debug.DebugTrace;
 
 import io.cucumber.core.eventbus.IncrementingUuidGenerator;
 import io.cucumber.core.exception.CompositeCucumberException;
@@ -77,98 +76,135 @@ public final class JavaGlueJob {
 			return resultsByDocument;
 		}
 
-		long start = System.currentTimeMillis();
-		DebugTrace debug = Tracing.get();
+		boolean perf = Tracing.PERF_STEPS;
+		long start = perf ? System.currentTimeMillis() : 0;
+		long startPhase = 0;
 
-		try (CucumberRuntime rt = CucumberRuntime.create(javaProject)) {
-			rt.setGenerator(new IncrementingUuidGenerator());
-			RuntimeOptionsBuilder runtimeOptions = rt.getRuntimeOptions();
-			runtimeOptions.setDryRun();
-
-			// Add all features to the runtime and map them by URI
-			Map<URI, GherkinEditorDocument> documentsByUri = new HashMap<>();
-			for (GherkinEditorDocument editorDocument : editorDocuments) {
-				if (monitor.isCanceled()) {
-					break;
-				}
-
-				IResource resource = editorDocument.getResource();
-				monitor.subTask(resource.getName());
-				debug.traceEntry(PERFORMANCE_STEPS, resource);
-
-				try {
-					Optional<Feature> feature = rt.addFeature(editorDocument);
-					if (feature.isPresent()) {
-						URI featureUri = feature.get().getUri();
-						documentsByUri.put(featureUri, editorDocument);
-					}
-				} catch (FeatureParserException e) {
-					// the feature has syntax errors, we can't check the glue then...
-					continue;
-				}
+		try {
+			// --- Phase 1: Create classloader and Cucumber runtime ---
+			if (perf) {
+				startPhase = System.currentTimeMillis();
+			}
+			CucumberRuntime rt = CucumberRuntime.create(javaProject);
+			if (perf) {
+				Tracing.get().trace(PERFORMANCE_STEPS, "[" + javaProject.getElementName() + "] Classloader created in "
+						+ (System.currentTimeMillis() - startPhase) + "ms");
 			}
 
-			if (documentsByUri.isEmpty()) {
-				return resultsByDocument;
-			}
+			try (rt) {
+				rt.setGenerator(new IncrementingUuidGenerator());
+				RuntimeOptionsBuilder runtimeOptions = rt.getRuntimeOptions();
+				runtimeOptions.setDryRun();
 
-			addGlueOptions(runtimeOptions, projectPreferences);
-
-			CucumberMissingStepsPlugin missingStepsPlugin = new CucumberMissingStepsPlugin();
-			CucumberStepParserPlugin stepParserPlugin = new CucumberStepParserPlugin();
-			CucumberMatchedStepsPlugin matchedStepsPlugin = new CucumberMatchedStepsPlugin();
-			rt.addPlugin(stepParserPlugin);
-			rt.addPlugin(matchedStepsPlugin);
-			rt.addPlugin(missingStepsPlugin);
-
-			// Add validation plugins
-			Map<String, Plugin> validationPluginInstances = new HashMap<>();
-			for (String pluginClass : validationPlugins) {
-				Plugin classpathPlugin = rt.addPluginFromClasspath(pluginClass);
-				if (classpathPlugin != null) {
-					validationPluginInstances.put(pluginClass, classpathPlugin);
+				// --- Phase 2: Parse and add all feature files ---
+				if (perf) {
+					startPhase = System.currentTimeMillis();
 				}
-			}
-
-			try {
-				rt.run(monitor);
-
-				// Process results for each document
-				Collection<CucumberStepDefinition> steps = stepParserPlugin.getStepList();
-
-				for (Map.Entry<URI, GherkinEditorDocument> entry : documentsByUri.entrySet()) {
+				Map<URI, GherkinEditorDocument> documentsByUri = new HashMap<>();
+				for (GherkinEditorDocument editorDocument : editorDocuments) {
 					if (monitor.isCanceled()) {
 						break;
 					}
 
-					URI uri = entry.getKey();
-					GherkinEditorDocument document = entry.getValue();
-					IResource resource = document.getResource();
+					IResource resource = editorDocument.getResource();
+					monitor.subTask(resource.getName());
 
-					// Get feature-specific results
-					Collection<MatchedStep<?>> matchedSteps = matchedStepsPlugin.getMatchedStepsForFeature(uri);
-					Map<Integer, Collection<String>> snippets = missingStepsPlugin.getSnippetsForFeature(uri);
-
-					// Collect validation errors from plugins
-					Map<Integer, String> validationErrors = new HashMap<>();
-					for (Plugin plugin : validationPluginInstances.values()) {
-						addErrors(plugin, validationErrors);
+					try {
+						Optional<Feature> feature = rt.addFeature(editorDocument);
+						if (feature.isPresent()) {
+							URI featureUri = feature.get().getUri();
+							documentsByUri.put(featureUri, editorDocument);
+						}
+					} catch (FeatureParserException e) {
+						// the feature has syntax errors, we can't check the glue then...
+						continue;
 					}
-
-					// Create markers for this document
-					MarkerFactory.validationErrorOnStepDefinition(resource, validationErrors, false);
-					MarkerFactory.missingSteps(resource, snippets, Activator.PLUGIN_ID, false);
-
-					debug.traceExit(PERFORMANCE_STEPS, matchedSteps.size() + " step(s) /  " + steps.size()
-							+ " step(s)  matched, " + snippets.size() + " snippet(s) where suggested");
-
-					resultsByDocument.put(document, new GlueSteps(List.copyOf(steps), List.copyOf(matchedSteps)));
 				}
 
-				debug.trace(PERFORMANCE_STEPS, "Total validation time for " + documentsByUri.size() + " document(s): "
-						+ (System.currentTimeMillis() - start) + "ms");
-			} catch (Throwable e) {
-				handleGlueValidationError(e, documentsByUri.values());
+				if (perf) {
+					Tracing.get().trace(PERFORMANCE_STEPS, "[" + javaProject.getElementName() + "] Parsed "
+							+ documentsByUri.size() + "/" + editorDocuments.size()
+							+ " feature(s) in " + (System.currentTimeMillis() - startPhase) + "ms");
+				}
+
+				if (documentsByUri.isEmpty()) {
+					return resultsByDocument;
+				}
+
+				addGlueOptions(runtimeOptions, projectPreferences);
+
+				CucumberMissingStepsPlugin missingStepsPlugin = new CucumberMissingStepsPlugin();
+				CucumberStepParserPlugin stepParserPlugin = new CucumberStepParserPlugin();
+				CucumberMatchedStepsPlugin matchedStepsPlugin = new CucumberMatchedStepsPlugin();
+				rt.addPlugin(stepParserPlugin);
+				rt.addPlugin(matchedStepsPlugin);
+				rt.addPlugin(missingStepsPlugin);
+
+				// Add validation plugins
+				Map<String, Plugin> validationPluginInstances = new HashMap<>();
+				for (String pluginClass : validationPlugins) {
+					Plugin classpathPlugin = rt.addPluginFromClasspath(pluginClass);
+					if (classpathPlugin != null) {
+						validationPluginInstances.put(pluginClass, classpathPlugin);
+					}
+				}
+
+				try {
+					// --- Phase 3: Run Cucumber (classloading + step matching) ---
+					if (perf) {
+						startPhase = System.currentTimeMillis();
+					}
+					rt.run(monitor);
+					if (perf) {
+						Tracing.get().trace(PERFORMANCE_STEPS, "[" + javaProject.getElementName()
+								+ "] Runtime (glue load + match) took " + (System.currentTimeMillis() - startPhase) + "ms"
+								+ " for " + documentsByUri.size() + " feature(s),"
+								+ " glue filters: " + projectPreferences.glueFilter());
+					}
+
+					// --- Phase 4: Process per-document results ---
+					Collection<CucumberStepDefinition> steps = stepParserPlugin.getStepList();
+
+					for (Map.Entry<URI, GherkinEditorDocument> entry : documentsByUri.entrySet()) {
+						if (monitor.isCanceled()) {
+							break;
+						}
+
+						URI uri = entry.getKey();
+						GherkinEditorDocument document = entry.getValue();
+						IResource resource = document.getResource();
+
+						// Get feature-specific results
+						Collection<MatchedStep<?>> matchedSteps = matchedStepsPlugin.getMatchedStepsForFeature(uri);
+						Map<Integer, Collection<String>> snippets = missingStepsPlugin.getSnippetsForFeature(uri);
+
+						// Collect validation errors from plugins
+						Map<Integer, String> validationErrors = new HashMap<>();
+						for (Plugin plugin : validationPluginInstances.values()) {
+							addErrors(plugin, validationErrors);
+						}
+
+						// Create markers for this document
+						MarkerFactory.validationErrorOnStepDefinition(resource, validationErrors, false);
+						MarkerFactory.missingSteps(resource, snippets, Activator.PLUGIN_ID, false);
+
+						if (perf) {
+							Tracing.get().trace(PERFORMANCE_STEPS, "  " + resource.getName() + ": "
+									+ matchedSteps.size() + "/" + steps.size()
+									+ " steps matched, " + snippets.size() + " missing");
+						}
+
+						resultsByDocument.put(document, new GlueSteps(List.copyOf(steps), List.copyOf(matchedSteps)));
+					}
+
+					if (perf) {
+						Tracing.get().trace(PERFORMANCE_STEPS, "[" + javaProject.getElementName()
+								+ "] Total glue validation: " + (System.currentTimeMillis() - start) + "ms"
+								+ " (" + documentsByUri.size() + " doc(s), " + stepParserPlugin.getStepList().size() + " step def(s))");
+					}
+				} catch (Throwable e) {
+					handleGlueValidationError(e, documentsByUri.values());
+				}
 			}
 		} catch (CoreException e) {
 			EditorLogging.error("Failed to create Cucumber runtime", e);

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/validation/JavaGlueValidatorService.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/validation/JavaGlueValidatorService.java
@@ -21,6 +21,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 
 import io.cucumber.eclipse.editor.EditorReconciler;
+import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocument;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocumentManager;
 import io.cucumber.eclipse.editor.document.IGherkinDocumentListener;
@@ -66,6 +67,9 @@ public class JavaGlueValidatorService implements IGlueValidator, JavaGlueStore, 
 	@Override
 	public void validate(Collection<GherkinEditorDocument> editorDocuments, IProgressMonitor monitor)
 			throws CoreException {
+		boolean perf = Tracing.PERF_STEPS;
+		long start = perf ? System.currentTimeMillis() : 0;
+
 		// Group documents by Java project for efficient batch processing
 		Map<IJavaProject, List<GherkinEditorDocument>> documentsByProject = new HashMap<>();
 		
@@ -90,6 +94,11 @@ public class JavaGlueValidatorService implements IGlueValidator, JavaGlueStore, 
 			if (javaProject != null && javaProject.exists()) {
 				documentsByProject.computeIfAbsent(javaProject, k -> new java.util.ArrayList<>()).add(editorDocument);
 			}
+		}
+
+		if (perf) {
+			Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "Glue validation dispatched: "
+					+ editorDocuments.size() + " doc(s) across " + documentsByProject.size() + " project(s)");
 		}
 		
 		// Process each Java project's documents with shared runtime setup
@@ -135,6 +144,11 @@ public class JavaGlueValidatorService implements IGlueValidator, JavaGlueStore, 
 					}
 				}
 			}
+		}
+
+		if (perf) {
+			Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "Glue validation complete: "
+					+ editorDocuments.size() + " doc(s) in " + (System.currentTimeMillis() - start) + "ms");
 		}
 	}
 


### PR DESCRIPTION
 Add sub-phase timing to JavaGlueJob (classloader, feature parsing,
 runtime execution, result processing), VerificationJob,
DocumentValidator (revalidation counts), CucumberFeatureBuilder, JavaGlueValidatorService,
 and CucumberStepDefinitionProvider. Fix string concatenation in hot paths to only execute when tracing is enabled. Update performance-tuning.md with annotated sample output and interpretation guidance.
