### PR TITLE
Reuse already-resolved IType instead of re-resolving it in resolveMethod

### DIFF
--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -93,7 +93,7 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 		});
 		if (type != null) {
 			try {
-				IMethod[] methods = JDTUtil.resolveMethod(project, codeLocation, monitor);
+				IMethod[] methods = JDTUtil.resolveTypeMethod(type, codeLocation, monitor);
 				if (methods.length == 1) {
 					// perfect match
 					IMethod method = methods[0];


### PR DESCRIPTION
CucumberStepDefinitionProvider.parseStepDefintion already resolves and caches the step definition's declaring IType via typeBuffer before this call. JDTUtil.resolveMethod(IJavaProject, CucumberCodeLocation, IProgressMonitor) independently calls project.findType(typeName, ...) again internally before delegating to resolveTypeMethod(IType, ...) - discarding the type we already have.

Call resolveTypeMethod(IType, ...) directly with the already-resolved type instead, removing one redundant JDT type-resolution call per step definition. Pure simplification, no behavior change: resolveMethod's only other job was resolving the type and delegating to resolveTypeMethod, which this now does explicitly at the call site.

resolveMethod itself is left untouched and still used by the three other call sites that do not have a pre-existing type cache (JavaStepDefinitionOpener, CucumberJavaQueryParticipant, JavaReferencesCodeMiningProvider).
