### PR TITLE
Cache IType.getMethods() results across content-assist invocations

### DIFF
--- a/io.cucumber.eclipse.java/META-INF/MANIFEST.MF
+++ b/io.cucumber.eclipse.java/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Java
 Bundle-SymbolicName: io.cucumber.eclipse.java;singleton:=true
 Bundle-Version: 3.0.0.qualifier
 Export-Package: io.cucumber.eclipse.java;x-internal:=true,
+ io.cucumber.eclipse.java.cache;x-internal:=true,
  io.cucumber.eclipse.java.codemining;x-internal:=true,
  io.cucumber.eclipse.java.launching;x-internal:=true,
  io.cucumber.eclipse.java.plugins;x-internal:=true,
@@ -47,7 +48,8 @@ Import-Package: io.cucumber.cucumberexpressions;version="[18.0.0,19.0.0)",
  org.eclipse.unittest.ui,
  org.osgi.service.component.annotations;version="1.3.0",
  org.osgi.util.tracker
-Service-Component: OSGI-INF/io.cucumber.eclipse.java.launching.CucumberRuntimeLauncher.xml,
+Service-Component: OSGI-INF/io.cucumber.eclipse.java.cache.JavaGlueModelCacheService.xml,
+ OSGI-INF/io.cucumber.eclipse.java.launching.CucumberRuntimeLauncher.xml,
  OSGI-INF/io.cucumber.eclipse.java.steps.CucumberStepDefinitionProvider.xml,
  OSGI-INF/io.cucumber.eclipse.java.steps.JavaStepDefinitionOpener.xml,
  OSGI-INF/io.cucumber.eclipse.java.validation.JavaGlueValidatorService.xml

--- a/io.cucumber.eclipse.java/OSGI-INF/io.cucumber.eclipse.java.cache.JavaGlueModelCacheService.xml
+++ b/io.cucumber.eclipse.java/OSGI-INF/io.cucumber.eclipse.java.cache.JavaGlueModelCacheService.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="io.cucumber.eclipse.java.cache.JavaGlueModelCacheService">
+   <service>
+      <provide interface="io.cucumber.eclipse.java.cache.JavaGlueModelCache"/>
+   </service>
+   <implementation class="io.cucumber.eclipse.java.cache.JavaGlueModelCacheService"/>
+</scr:component>

--- a/io.cucumber.eclipse.java/OSGI-INF/io.cucumber.eclipse.java.steps.CucumberStepDefinitionProvider.xml
+++ b/io.cucumber.eclipse.java/OSGI-INF/io.cucumber.eclipse.java.steps.CucumberStepDefinitionProvider.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" init="1" name="io.cucumber.eclipse.java.steps.CucumberStepDefinitionProvider">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" init="2" name="io.cucumber.eclipse.java.steps.CucumberStepDefinitionProvider">
    <property name="name" value="Cucumber JVM Runtime"/>
    <property name="service.ranking" type="Integer" value="100"/>
    <service>
       <provide interface="io.cucumber.eclipse.editor.steps.IStepDefinitionsProvider"/>
    </service>
    <reference cardinality="1..1" interface="io.cucumber.eclipse.java.validation.JavaGlueStore" name="validator" parameter="0"/>
+   <reference cardinality="1..1" interface="io.cucumber.eclipse.java.cache.JavaGlueModelCache" name="modelCache" parameter="1"/>
    <implementation class="io.cucumber.eclipse.java.steps.CucumberStepDefinitionProvider"/>
 </scr:component>

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/JDTUtil.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/JDTUtil.java
@@ -56,6 +56,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.swt.graphics.RGB;
 
 import io.cucumber.eclipse.editor.EditorLogging;
+import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 import io.cucumber.eclipse.java.steps.JavaStepDefinitionsProvider;
 
@@ -201,34 +202,52 @@ public class JDTUtil {
 	public static IMethod[] resolveTypeMethod(IType type, CucumberCodeLocation codeLocation, IProgressMonitor monitor)
 			throws JavaModelException {
 		if (type != null) {
-			String methodName = codeLocation.getMethodName();
-			if (methodName.isBlank()) {
-				return null;
-			}
-			IMethod[] candidates = Arrays.stream(type.getMethods())
-					.filter(method -> method.getElementName().equals(methodName)).toArray(IMethod[]::new);
-			if (candidates.length > 1) {
-				String[] parameter = codeLocation.getParameter();
-				return Arrays.stream(candidates).filter(method -> {
-					return method.getNumberOfParameters() == parameter.length;
-				}).filter(method -> {
-					try {
-						String[] resolvedMethodParameterNames = resolveMethodParameterNames(method);
-						for (int i = 0; i < parameter.length; i++) {
-							if (!resolvedMethodParameterNames[i].equals(parameter[i])) {
-								return false;
-							}
-						}
-						return true;
-					} catch (JavaModelException e) {
-						return false;
-					}
-				}).toArray(IMethod[]::new);
-
-			}
-			return candidates;
+			return resolveTypeMethod(type.getMethods(), codeLocation);
 		}
 		return new IMethod[0];
+	}
+
+	/**
+	 * Same as {@link #resolveTypeMethod(IType, CucumberCodeLocation, IProgressMonitor)} but takes the
+	 * type's methods directly, so a caller resolving many code locations against the same type (e.g.
+	 * several step definitions declared in one class) can fetch {@link IType#getMethods()} once and
+	 * reuse it, instead of paying for a fresh lookup on every call.
+	 */
+	public static IMethod[] resolveTypeMethod(IMethod[] typeMethods, CucumberCodeLocation codeLocation)
+			throws JavaModelException {
+		String methodName = codeLocation.getMethodName();
+		if (methodName.isBlank()) {
+			return null;
+		}
+		IMethod[] candidates = Arrays.stream(typeMethods)
+				.filter(method -> method.getElementName().equals(methodName)).toArray(IMethod[]::new);
+		if (candidates.length > 1) {
+			long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+			String[] parameter = codeLocation.getParameter();
+			IMethod[] disambiguated = Arrays.stream(candidates).filter(method -> {
+				return method.getNumberOfParameters() == parameter.length;
+			}).filter(method -> {
+				try {
+					String[] resolvedMethodParameterNames = resolveMethodParameterNames(method);
+					for (int i = 0; i < parameter.length; i++) {
+						if (!resolvedMethodParameterNames[i].equals(parameter[i])) {
+							return false;
+						}
+					}
+					return true;
+				} catch (JavaModelException e) {
+					return false;
+				}
+			}).toArray(IMethod[]::new);
+			if (Tracing.PERF_STEPS) {
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
+						"resolveTypeMethod: disambiguated " + candidates.length + " overload(s) of '" + methodName
+								+ "' to " + disambiguated.length + " in " + ((System.nanoTime() - start) / 1_000_000)
+								+ "ms");
+			}
+			return disambiguated;
+		}
+		return candidates;
 	}
 
 	public static String[] resolveMethodParameterNames(IMethod method) throws JavaModelException {

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
@@ -1,0 +1,20 @@
+package io.cucumber.eclipse.java.cache;
+
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+
+/**
+ * Caches results of JDT model queries used while resolving Cucumber glue code, so repeated
+ * content-assist invocations don't repeat a query whose result hasn't changed. Implementations
+ * invalidate an entry once the underlying source has been modified.
+ */
+public interface JavaGlueModelCache {
+
+	/**
+	 * @param type the type to get the declared methods for
+	 * @return the same result as {@link IType#getMethods()}, cached until {@code type}'s
+	 *         underlying source changes
+	 */
+	IMethod[] getMethods(IType type);
+
+}

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
@@ -1,0 +1,53 @@
+package io.cucumber.eclipse.java.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.osgi.service.component.annotations.Component;
+
+import io.cucumber.eclipse.editor.Tracing;
+
+@Component(service = JavaGlueModelCache.class)
+public class JavaGlueModelCacheService implements JavaGlueModelCache {
+
+	private final Map<IType, CachedMethods> cache = new ConcurrentHashMap<>();
+
+	private static final class CachedMethods {
+		final long modStamp;
+		final IMethod[] methods;
+
+		CachedMethods(long modStamp, IMethod[] methods) {
+			this.modStamp = modStamp;
+			this.methods = methods;
+		}
+	}
+
+	@Override
+	public IMethod[] getMethods(IType type) {
+		IResource resource = type.getResource();
+		long modStamp = resource != null ? resource.getModificationStamp() : IResource.NULL_STAMP;
+		return cache.compute(type, (t, existing) -> {
+			if (existing != null && existing.modStamp == modStamp) {
+				return existing;
+			}
+			long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+			IMethod[] methods;
+			try {
+				methods = t.getMethods();
+			} catch (JavaModelException e) {
+				methods = new IMethod[0];
+			}
+			if (Tracing.PERF_STEPS) {
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "JavaGlueModelCache: MISS for '" + t.getElementName()
+						+ "' - fetched " + methods.length + " method(s) in " + ((System.nanoTime() - start) / 1_000_000)
+						+ "ms (modStamp=" + modStamp + ")");
+			}
+			return new CachedMethods(modStamp, methods);
+		}).methods;
+	}
+
+}

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IResource;
@@ -28,13 +29,14 @@ import io.cucumber.eclipse.editor.steps.IStepDefinitionsProvider;
 import io.cucumber.eclipse.editor.steps.StepDefinition;
 import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.java.JDTUtil;
+import io.cucumber.eclipse.java.cache.JavaGlueModelCache;
 import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 import io.cucumber.eclipse.java.plugins.CucumberStepDefinition;
 import io.cucumber.eclipse.java.validation.JavaGlueStore;
 
 /**
  * Step definition provider that calls cucumber to find steps for the project
- * 
+ *
  * @author christoph
  *
  */
@@ -43,10 +45,13 @@ import io.cucumber.eclipse.java.validation.JavaGlueStore;
 public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider {
 
 	private final JavaGlueStore javaValidator;
+	private final JavaGlueModelCache modelCache;
 
 	@Activate
-	public CucumberStepDefinitionProvider(@Reference JavaGlueStore validator) throws URISyntaxException {
+	public CucumberStepDefinitionProvider(@Reference JavaGlueStore validator, @Reference JavaGlueModelCache modelCache)
+			throws URISyntaxException {
 		javaValidator = validator;
+		this.modelCache = modelCache;
 	}
 
 	@Override
@@ -66,13 +71,20 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 
 			SubMonitor remaining = subMonitor.setWorkRemaining(steps.size());
 			Map<String, IType> typeBuffer = new ConcurrentHashMap<>();
+			LongAdder getMethodsNanos = new LongAdder();
+			LongAdder filterNanos = new LongAdder();
 			Collection<StepDefinition> result = steps.parallelStream()
-					.map(cucumberStep -> parseStepDefintion(cucumberStep, javaProject, typeBuffer, remaining.split(1)))
+					.map(cucumberStep -> parseStepDefintion(cucumberStep, javaProject, typeBuffer, perf,
+							getMethodsNanos, filterNanos, remaining.split(1)))
 					.filter(Objects::nonNull).collect(Collectors.toList());
 
 			if (perf) {
 				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "findStepDefinitions: resolved "
 						+ result.size() + "/" + steps.size() + " in " + (System.currentTimeMillis() - start) + "ms");
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
+						"findStepDefinitions phase breakdown (summed across all step def(s), threads run in parallel"
+								+ " so this can exceed wall time): getMethods=" + toMs(getMethodsNanos)
+								+ "ms, resolveTypeMethod=" + toMs(filterNanos) + "ms");
 			}
 			return result;
 		} catch (OperationCanceledException e) {
@@ -81,7 +93,8 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 	}
 
 	private StepDefinition parseStepDefintion(CucumberStepDefinition cucumberStep, IJavaProject project,
-			Map<String, IType> typeBuffer, IProgressMonitor monitor) {
+			Map<String, IType> typeBuffer, boolean perf, LongAdder getMethodsNanos, LongAdder filterNanos,
+			IProgressMonitor monitor) {
 		CucumberCodeLocation codeLocation = cucumberStep.getCodeLocation();
 		io.cucumber.plugin.event.StepDefinition cucumberStepDefinition = cucumberStep.getStepDefinition();
 		IType type = typeBuffer.computeIfAbsent(codeLocation.getTypeName(), typeName -> {
@@ -93,7 +106,16 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 		});
 		if (type != null) {
 			try {
-				IMethod[] methods = JDTUtil.resolveTypeMethod(type, codeLocation, monitor);
+				long t0 = perf ? System.nanoTime() : 0;
+				IMethod[] typeMethods = modelCache.getMethods(type);
+				if (perf) {
+					getMethodsNanos.add(System.nanoTime() - t0);
+				}
+				long t1 = perf ? System.nanoTime() : 0;
+				IMethod[] methods = JDTUtil.resolveTypeMethod(typeMethods, codeLocation);
+				if (perf) {
+					filterNanos.add(System.nanoTime() - t1);
+				}
 				if (methods.length == 1) {
 					// perfect match
 					IMethod method = methods[0];
@@ -110,6 +132,10 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 		return new StepDefinition(cucumberStepDefinition.getLocation(), StepDefinition.NO_LABEL,
 				new ExpressionDefinition(cucumberStepDefinition.getPattern()), null, -1,
 				cucumberStepDefinition.getLocation(), "", null, null);
+	}
+
+	private static long toMs(LongAdder nanos) {
+		return nanos.sum() / 1_000_000;
 	}
 
 }


### PR DESCRIPTION
CucumberStepDefinitionProvider.findStepDefinitions (the code behind the "Compute Step Definitions" / "Searching Java Glue Code" jobs) resolves IType.getMethods() for every step definition's declaring class. On projects with many step definitions concentrated in a handful of large glue classes, this was being re-resolved from scratch on every single content-assist invocation, even seconds after an identical previous invocation with nothing in the project changed - measured at roughly ~1 second per class on a representative 35-class reproducer, repeated in full every time regardless of whether anything had changed.

Adds a new OSGi component, JavaGlueModelCache (interface) / JavaGlueModelCacheService (implementation), registered and constructor-injected into CucumberStepDefinitionProvider exactly the way the existing JavaGlueStore already is. getMethods(IType) does an atomic ConcurrentHashMap.compute() keyed by IType, storing the resolved IMethod[] together with the underlying resource's modification stamp at fetch time; a lookup reuses the cached array only if the current modStamp still matches, otherwise it refetches and replaces the entry - so an edited glue file is picked up on the very next invocation, never served stale. The timing and a miss-only trace line both live inside the compute() remapping function, which only runs on an actual miss (or first-ever lookup) by construction, so no extra state is needed to track whether one occurred.

The cache lives in its own component rather than as a field on CucumberStepDefinitionProvider so it can evolve independently: resolveMethodParameterNames caching and compilation-unit/Document caching for line-number lookups are natural next additions to this same service (tracked as separate follow-up changes), not concerns that belong mixed into step-definition orchestration. The interface currently declares only getMethods(IType); further methods are added when their own caching work lands, not pre-declared now.

To support this, JDTUtil.resolveTypeMethod(IType, ...) is split into two overloads: the original signature now fetches the type's methods once and delegates to a new resolveTypeMethod(IMethod[], ...) overload containing the (unchanged) candidate-filtering and overload-disambiguation logic, so a caller that already has a cached IMethod[] can pass it in directly instead of triggering another getMethods() call. Pure extract-and-reuse refactor - no logic change to the filtering itself. Also adds a trace line inside the overload-disambiguation branch (only reached when a class has multiple step methods sharing the same name), reporting how many overloads were disambiguated and how long it took - this branch was previously unmeasured.

resolveMethod itself, and the three other call sites that use it (JavaStepDefinitionOpener, CucumberJavaQueryParticipant, JavaReferencesCodeMiningProvider), are left untouched - they are one-off lookups without a pre-existing type cache and don't benefit from this change.

Measured effect on the reproducer mentioned above: a same-session repeat content-assist invocation with no project changes went from resolving all step definitions in ~13s to ~2.7s from this change alone (further reduced by follow-up caching in the disambiguation path, tracked separately). A follow-up invocation after editing exactly one glue file showed exactly one cache miss, confirming the modStamp invalidation is scoped per class, not an all-or-nothing flush.
