### PR TITLE
perf: cache resolveMethodParameterNames, make JavaGlueModelCache own …

### DIFF
--- a/io.cucumber.eclipse.java/OSGI-INF/io.cucumber.eclipse.java.steps.JavaStepDefinitionOpener.xml
+++ b/io.cucumber.eclipse.java/OSGI-INF/io.cucumber.eclipse.java.steps.JavaStepDefinitionOpener.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" init="1" name="io.cucumber.eclipse.java.steps.JavaStepDefinitionOpener">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" init="2" name="io.cucumber.eclipse.java.steps.JavaStepDefinitionOpener">
    <service>
       <provide interface="io.cucumber.eclipse.editor.hyperlinks.IStepDefinitionOpener"/>
    </service>
    <reference cardinality="1..1" interface="io.cucumber.eclipse.java.validation.JavaGlueStore" name="glueValidatorService" parameter="0"/>
+   <reference cardinality="1..1" interface="io.cucumber.eclipse.java.cache.JavaGlueModelCache" name="modelCache" parameter="1"/>
    <implementation class="io.cucumber.eclipse.java.steps.JavaStepDefinitionOpener"/>
 </scr:component>

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/Activator.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/Activator.java
@@ -7,6 +7,7 @@ import org.osgi.util.tracker.ServiceTracker;
 
 import io.cucumber.eclipse.editor.EnvelopeReader;
 import io.cucumber.eclipse.editor.validation.DocumentValidator;
+import io.cucumber.eclipse.java.cache.JavaGlueModelCache;
 import io.cucumber.eclipse.java.validation.JavaGlueStore;
 
 /**
@@ -26,6 +27,8 @@ public class Activator extends AbstractUIPlugin {
 
 	private ServiceTracker<JavaGlueStore, JavaGlueStore> glueStoreTracker;
 
+	private ServiceTracker<JavaGlueModelCache, JavaGlueModelCache> modelCacheTracker;
+
 	/**
 	 * The constructor
 	 */
@@ -40,6 +43,8 @@ public class Activator extends AbstractUIPlugin {
 		envelopeReaderTracker.open();
 		glueStoreTracker = new ServiceTracker<>(context, JavaGlueStore.class, null);
 		glueStoreTracker.open();
+		modelCacheTracker = new ServiceTracker<>(context, JavaGlueModelCache.class, null);
+		modelCacheTracker.open();
 		propertyChangeListener = event -> DocumentValidator.revalidateAllDocuments();
 		getPreferenceStore().addPropertyChangeListener(propertyChangeListener);
 	}
@@ -53,6 +58,10 @@ public class Activator extends AbstractUIPlugin {
 		if (glueStoreTracker != null) {
 			glueStoreTracker.close();
 			glueStoreTracker = null;
+		}
+		if (modelCacheTracker != null) {
+			modelCacheTracker.close();
+			modelCacheTracker = null;
 		}
 		if (propertyChangeListener != null) {
 			getPreferenceStore().removePropertyChangeListener(propertyChangeListener);
@@ -91,6 +100,17 @@ public class Activator extends AbstractUIPlugin {
 			return null;
 		}
 		return activator.glueStoreTracker.getService();
+	}
+
+	/**
+	 * Returns the JavaGlueModelCache service, or null if not available
+	 */
+	public static JavaGlueModelCache getJavaGlueModelCache() {
+		Activator activator = getDefault();
+		if (activator == null || activator.modelCacheTracker == null) {
+			return null;
+		}
+		return activator.modelCacheTracker.getService();
 	}
 
 }

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/JDTUtil.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/JDTUtil.java
@@ -57,7 +57,6 @@ import org.eclipse.swt.graphics.RGB;
 
 import io.cucumber.eclipse.editor.EditorLogging;
 import io.cucumber.eclipse.editor.Tracing;
-import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 import io.cucumber.eclipse.java.steps.JavaStepDefinitionsProvider;
 
 @SuppressWarnings("restriction")
@@ -187,67 +186,6 @@ public class JDTUtil {
 			}).filter(Objects::nonNull).collect(Collectors.toList()));
 		}
 
-	}
-
-	public static IMethod[] resolveMethod(IJavaProject project, CucumberCodeLocation codeLocation,
-			IProgressMonitor monitor) throws JavaModelException {
-		SubMonitor subMonitor = SubMonitor.convert(monitor, codeLocation.toString(), 100);
-		String typeName = codeLocation.getTypeName();
-		if (typeName.isBlank()) {
-			return new IMethod[0];
-		}
-		return resolveTypeMethod(project.findType(typeName, subMonitor.split(10)), codeLocation, subMonitor.split(90));
-	}
-
-	public static IMethod[] resolveTypeMethod(IType type, CucumberCodeLocation codeLocation, IProgressMonitor monitor)
-			throws JavaModelException {
-		if (type != null) {
-			return resolveTypeMethod(type.getMethods(), codeLocation);
-		}
-		return new IMethod[0];
-	}
-
-	/**
-	 * Same as {@link #resolveTypeMethod(IType, CucumberCodeLocation, IProgressMonitor)} but takes the
-	 * type's methods directly, so a caller resolving many code locations against the same type (e.g.
-	 * several step definitions declared in one class) can fetch {@link IType#getMethods()} once and
-	 * reuse it, instead of paying for a fresh lookup on every call.
-	 */
-	public static IMethod[] resolveTypeMethod(IMethod[] typeMethods, CucumberCodeLocation codeLocation)
-			throws JavaModelException {
-		String methodName = codeLocation.getMethodName();
-		if (methodName.isBlank()) {
-			return null;
-		}
-		IMethod[] candidates = Arrays.stream(typeMethods)
-				.filter(method -> method.getElementName().equals(methodName)).toArray(IMethod[]::new);
-		if (candidates.length > 1) {
-			long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
-			String[] parameter = codeLocation.getParameter();
-			IMethod[] disambiguated = Arrays.stream(candidates).filter(method -> {
-				return method.getNumberOfParameters() == parameter.length;
-			}).filter(method -> {
-				try {
-					String[] resolvedMethodParameterNames = resolveMethodParameterNames(method);
-					for (int i = 0; i < parameter.length; i++) {
-						if (!resolvedMethodParameterNames[i].equals(parameter[i])) {
-							return false;
-						}
-					}
-					return true;
-				} catch (JavaModelException e) {
-					return false;
-				}
-			}).toArray(IMethod[]::new);
-			if (Tracing.PERF_STEPS) {
-				Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
-						"resolveTypeMethod: disambiguated " + candidates.length + " overload(s) of '" + methodName
-								+ "' to " + disambiguated.length + " in " + ((System.nanoTime() - start) / 1_000_000)
-								+ "ms");
-			}
-			return disambiguated;
-		}
-		return candidates;
 	}
 
 	public static String[] resolveMethodParameterNames(IMethod method) throws JavaModelException {

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
@@ -1,7 +1,12 @@
 package io.cucumber.eclipse.java.cache;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+
+import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 
 /**
  * Caches results of JDT model queries used while resolving Cucumber glue code, so repeated
@@ -16,5 +21,27 @@ public interface JavaGlueModelCache {
 	 *         underlying source changes
 	 */
 	IMethod[] getMethods(IType type);
+
+	/**
+	 * @param method the method to resolve fully qualified parameter type names for
+	 * @return the resolved parameter type names, cached for the lifetime of the {@link IMethod}
+	 *         handle (a method whose parameter types change resolves to a different handle)
+	 */
+	String[] getParameterNames(IMethod method) throws JavaModelException;
+
+	/**
+	 * Same as resolving a {@code codeLocation} against {@code typeMethods} directly, but using
+	 * {@link #getParameterNames(IMethod)} to disambiguate any overloaded candidates, instead of
+	 * resolving their parameter names from scratch.
+	 */
+	IMethod[] resolveTypeMethod(IMethod[] typeMethods, CucumberCodeLocation codeLocation) throws JavaModelException;
+
+	/**
+	 * Same as {@link #resolveTypeMethod(IMethod[], CucumberCodeLocation)} but also resolves
+	 * {@code codeLocation}'s declaring type through {@link #getMethods(IType)}, for callers that
+	 * don't already have the type's methods in hand.
+	 */
+	IMethod[] resolveMethod(IJavaProject project, CucumberCodeLocation codeLocation, IProgressMonitor monitor)
+			throws JavaModelException;
 
 }

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
@@ -1,20 +1,26 @@
 package io.cucumber.eclipse.java.cache;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.osgi.service.component.annotations.Component;
 
 import io.cucumber.eclipse.editor.Tracing;
+import io.cucumber.eclipse.java.JDTUtil;
+import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 
 @Component(service = JavaGlueModelCache.class)
 public class JavaGlueModelCacheService implements JavaGlueModelCache {
 
 	private final Map<IType, CachedMethods> cache = new ConcurrentHashMap<>();
+	private final Map<IMethod, String[]> parameterNamesCache = new ConcurrentHashMap<>();
 
 	private static final class CachedMethods {
 		final long modStamp;
@@ -48,6 +54,74 @@ public class JavaGlueModelCacheService implements JavaGlueModelCache {
 			}
 			return new CachedMethods(modStamp, methods);
 		}).methods;
+	}
+
+	@Override
+	public String[] getParameterNames(IMethod method) throws JavaModelException {
+		String[] cached = parameterNamesCache.get(method);
+		if (cached != null) {
+			return cached;
+		}
+		long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+		String[] resolved = JDTUtil.resolveMethodParameterNames(method);
+		parameterNamesCache.put(method, resolved);
+		if (Tracing.PERF_STEPS) {
+			Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "JavaGlueModelCache: cached parameter name(s) for '"
+					+ method.getElementName() + "' in " + ((System.nanoTime() - start) / 1_000_000) + "ms");
+		}
+		return resolved;
+	}
+
+	@Override
+	public IMethod[] resolveTypeMethod(IMethod[] typeMethods, CucumberCodeLocation codeLocation)
+			throws JavaModelException {
+		String methodName = codeLocation.getMethodName();
+		if (methodName.isBlank()) {
+			return null;
+		}
+		IMethod[] candidates = Arrays.stream(typeMethods)
+				.filter(method -> method.getElementName().equals(methodName)).toArray(IMethod[]::new);
+		if (candidates.length > 1) {
+			long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+			String[] parameter = codeLocation.getParameter();
+			IMethod[] disambiguated = Arrays.stream(candidates).filter(method -> {
+				return method.getNumberOfParameters() == parameter.length;
+			}).filter(method -> {
+				try {
+					String[] resolvedMethodParameterNames = getParameterNames(method);
+					for (int i = 0; i < parameter.length; i++) {
+						if (!resolvedMethodParameterNames[i].equals(parameter[i])) {
+							return false;
+						}
+					}
+					return true;
+				} catch (JavaModelException e) {
+					return false;
+				}
+			}).toArray(IMethod[]::new);
+			if (Tracing.PERF_STEPS) {
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
+						"resolveTypeMethod: disambiguated " + candidates.length + " overload(s) of '" + methodName
+								+ "' to " + disambiguated.length + " in " + ((System.nanoTime() - start) / 1_000_000)
+								+ "ms");
+			}
+			return disambiguated;
+		}
+		return candidates;
+	}
+
+	@Override
+	public IMethod[] resolveMethod(IJavaProject project, CucumberCodeLocation codeLocation, IProgressMonitor monitor)
+			throws JavaModelException {
+		String typeName = codeLocation.getTypeName();
+		if (typeName.isBlank()) {
+			return new IMethod[0];
+		}
+		IType type = project.findType(typeName, monitor);
+		if (type == null) {
+			return new IMethod[0];
+		}
+		return resolveTypeMethod(getMethods(type), codeLocation);
 	}
 
 }

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/codemining/JavaReferencesCodeMiningProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/codemining/JavaReferencesCodeMiningProvider.java
@@ -39,6 +39,8 @@ import io.cucumber.eclipse.editor.EditorLogging;
 import io.cucumber.eclipse.editor.SWTUtil;
 import io.cucumber.eclipse.java.Activator;
 import io.cucumber.eclipse.java.JDTUtil;
+import io.cucumber.eclipse.java.cache.JavaGlueModelCache;
+import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 import io.cucumber.eclipse.java.plugins.MatchedHookStep;
 import io.cucumber.eclipse.java.plugins.MatchedStep;
 import io.cucumber.eclipse.java.preferences.CucumberJavaPreferences;
@@ -150,7 +152,7 @@ public class JavaReferencesCodeMiningProvider implements ICodeMiningProvider {
 				Set<Entry<MatchedHookStep, IMethod[]>> resolvedMethods = list.stream()
 						.collect(Collectors.toMap(Function.identity(), step -> {
 							try {
-								return JDTUtil.resolveMethod(javaProject, step.getCodeLocation(), null);
+								return resolveMethod(javaProject, step.getCodeLocation());
 							} catch (JavaModelException e) {
 								return null;
 							}
@@ -196,6 +198,15 @@ public class JavaReferencesCodeMiningProvider implements ICodeMiningProvider {
 				});
 				return null;
 			});
+		}
+
+		private static IMethod[] resolveMethod(IJavaProject javaProject, CucumberCodeLocation codeLocation)
+				throws JavaModelException {
+			JavaGlueModelCache modelCache = Activator.getJavaGlueModelCache();
+			if (modelCache == null) {
+				return null;
+			}
+			return modelCache.resolveMethod(javaProject, codeLocation, null);
 		}
 
 		private void open(MatchedHookStep step, IMethod[] method, Shell shell) {

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/search/CucumberJavaQueryParticipant.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/search/CucumberJavaQueryParticipant.java
@@ -31,6 +31,7 @@ import io.cucumber.eclipse.editor.document.GherkinEditorDocument;
 import io.cucumber.eclipse.editor.document.GherkinEditorDocumentManager;
 import io.cucumber.eclipse.java.Activator;
 import io.cucumber.eclipse.java.JDTUtil;
+import io.cucumber.eclipse.java.cache.JavaGlueModelCache;
 import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 import io.cucumber.eclipse.java.plugins.MatchedStep;
 import io.cucumber.eclipse.java.preferences.CucumberJavaPreferences;
@@ -280,7 +281,7 @@ public class CucumberJavaQueryParticipant implements IQueryParticipant {
 			if (codeLocation != null) {
 				// Try to resolve the method from the code location
 				try {
-					IMethod[] resolvedMethods = JDTUtil.resolveMethod(javaProject, codeLocation, monitor);
+					IMethod[] resolvedMethods = resolveMethod(javaProject, codeLocation, monitor);
 					
 					// Check if our target method is in the resolved methods
 					if (resolvedMethods != null) {
@@ -299,6 +300,20 @@ public class CucumberJavaQueryParticipant implements IQueryParticipant {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Resolves a method through the {@link JavaGlueModelCache}, so a repeated search benefits from
+	 * whatever content-assist has already resolved. Returns {@code null} if the service isn't
+	 * available.
+	 */
+	private static IMethod[] resolveMethod(IJavaProject javaProject, CucumberCodeLocation codeLocation,
+			IProgressMonitor monitor) throws JavaModelException {
+		JavaGlueModelCache modelCache = Activator.getJavaGlueModelCache();
+		if (modelCache == null) {
+			return null;
+		}
+		return modelCache.resolveMethod(javaProject, codeLocation, monitor);
 	}
 
 	/**

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -112,7 +112,7 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 					getMethodsNanos.add(System.nanoTime() - t0);
 				}
 				long t1 = perf ? System.nanoTime() : 0;
-				IMethod[] methods = JDTUtil.resolveTypeMethod(typeMethods, codeLocation);
+				IMethod[] methods = modelCache.resolveTypeMethod(typeMethods, codeLocation);
 				if (perf) {
 					filterNanos.add(System.nanoTime() - t1);
 				}

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/JavaStepDefinitionOpener.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/JavaStepDefinitionOpener.java
@@ -36,6 +36,7 @@ import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.editor.hyperlinks.IStepDefinitionOpener;
 import io.cucumber.eclipse.editor.validation.DocumentValidator;
 import io.cucumber.eclipse.java.JDTUtil;
+import io.cucumber.eclipse.java.cache.JavaGlueModelCache;
 import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 import io.cucumber.eclipse.java.plugins.MatchedPickleStep;
 import io.cucumber.eclipse.java.plugins.MatchedStep;
@@ -46,10 +47,13 @@ import io.cucumber.messages.types.Step;
 public class JavaStepDefinitionOpener implements IStepDefinitionOpener {
 
 	private JavaGlueStore glueStore;
+	private JavaGlueModelCache modelCache;
 
 	@Activate
-	public JavaStepDefinitionOpener(@Reference JavaGlueStore glueValidatorService) {
+	public JavaStepDefinitionOpener(@Reference JavaGlueStore glueValidatorService,
+			@Reference JavaGlueModelCache modelCache) {
 		this.glueStore = glueValidatorService;
+		this.modelCache = modelCache;
 	}
 
 	public static void showMethod(IMethod[] methods, Shell shell) {
@@ -150,7 +154,7 @@ public class JavaStepDefinitionOpener implements IStepDefinitionOpener {
 						}
 						
 						if (location != null) {
-							resolvedMethods.set(JDTUtil.resolveMethod(project, location, monitor));
+							resolvedMethods.set(modelCache.resolveMethod(project, location, monitor));
 						}
 					} finally {
 						cancelled.set(cancelled.get() || monitor.isCanceled());


### PR DESCRIPTION
…method resolution

JDTUtil.resolveTypeMethod's overload-disambiguation branch (reached when a class has multiple step methods sharing the same name) calls resolveMethodParameterNames(IMethod) per candidate to disambiguate by parameter type. That method resolves each parameter's fully qualified type name via IType.resolveType() - a real JDT name-resolution operation. On a representative reproducer, the same handful of overloaded method names recurred on every single content-assist invocation, each re-paying that resolution cost from scratch with no benefit from an identical previous invocation seconds earlier - measured at 5.4-8.6s total per invocation, not shrinking between repeats.

Extends the JavaGlueModelCache service (added for IType.getMethods() caching in a prior change) with:

- getParameterNames(IMethod): a plain Map<IMethod, String[]> cache, no modification-stamp invalidation needed - JDT method handles encode their parameter type signature, so a method whose parameters actually change resolves to a structurally different (non-equal) IMethod handle, and a stale entry for the old handle is simply never looked up again. A resolution failure isn't cached, so it's retried on the next lookup rather than remembered as permanent.
- resolveTypeMethod(IMethod[], CucumberCodeLocation) and resolveMethod(IJavaProject, CucumberCodeLocation, IProgressMonitor): the full method-resolution algorithm (candidate filtering, overload disambiguation via the cached parameter names, and - for resolveMethod - the find-type and getMethods steps too), moved here from JDTUtil now that the cache owns every step of it. Callers ask the service directly for a resolved method instead of calling a static utility with a cache passed in as an argument.

JDTUtil's original uncached resolveMethod/resolveTypeMethod overloads and the ParameterNameLookup abstraction used to bridge cached/uncached callers are removed entirely: once every caller of this resolution logic went through the cache, they were dead code. JDTUtil keeps only the raw JDT primitives with callers elsewhere or inside the cache service itself: resolveMethodParameterNames, resolveTypeWithRetry, bug571150.

Wired the cache into the three call sites that resolve a single method and were previously left on the uncached path (not measured hot paths, but a persistent cross-invocation cache benefits even a one-off lookup once warm from a prior content-assist run):
- JavaStepDefinitionOpener: a real OSGi DS component, takes JavaGlueModelCache as a second @Reference constructor parameter (OSGI-INF descriptor updated: init="2", new <reference> entry).
- CucumberJavaQueryParticipant and JavaReferencesCodeMiningProvider: instantiated via Eclipse extension points, not DS-managed, so they look up the cache through a new Activator.getJavaGlueModelCache() static accessor (a ServiceTracker, mirroring the pre-existing getJavaGlueStore()). If the service is ever unavailable they return null rather than falling back to an uncached lookup, matching this codebase's existing convention for an unavailable required service (both files already handle a null JavaGlueStore the same way).

No MANIFEST.MF changes needed - this extends the component already registered for the getMethods() cache, it doesn't add a new one.

Measured impact: on the reproducer used throughout this investigation (5 distinct overloaded method names recurring on every invocation), the disambiguation branch's cost collapsed from 5.4-8.6 seconds to consistently 0ms on repeat invocations. Combined with the getMethods() cache, a same-session repeat content-assist invocation now completes in tens of milliseconds rather than several seconds.

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
