### PR TITLE
perf: cache the Document used for line-number lookups in JavaGlueModelCache

### DIFF
--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
@@ -1,8 +1,10 @@
 package io.cucumber.eclipse.java.cache;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 
@@ -43,5 +45,14 @@ public interface JavaGlueModelCache {
 	 */
 	IMethod[] resolveMethod(IJavaProject project, CucumberCodeLocation codeLocation, IProgressMonitor monitor)
 			throws JavaModelException;
+
+	/**
+	 * @param compUnit the compilation unit {@code annotation} is declared in
+	 * @param annotation the source element to resolve a line number for
+	 * @return the 1-based line number {@code annotation} starts at, or {@code -1} if it can't be
+	 *         resolved. The {@link org.eclipse.jface.text.Document} used to compute this is cached
+	 *         until {@code compUnit}'s underlying source changes.
+	 */
+	int getLineNumber(ICompilationUnit compUnit, ISourceReference annotation) throws JavaModelException;
 
 }

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
@@ -6,10 +6,14 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
 import org.osgi.service.component.annotations.Component;
 
 import io.cucumber.eclipse.editor.Tracing;
@@ -19,8 +23,12 @@ import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 @Component(service = JavaGlueModelCache.class)
 public class JavaGlueModelCacheService implements JavaGlueModelCache {
 
+	/** {@link #getDocument(ICompilationUnit)} misses at or above this cost get their own trace line. */
+	private static final long SLOW_MISS_THRESHOLD_MS = 200;
+
 	private final Map<IType, CachedMethods> cache = new ConcurrentHashMap<>();
 	private final Map<IMethod, String[]> parameterNamesCache = new ConcurrentHashMap<>();
+	private final Map<ICompilationUnit, CachedDocument> documentCache = new ConcurrentHashMap<>();
 
 	private static final class CachedMethods {
 		final long modStamp;
@@ -29,6 +37,16 @@ public class JavaGlueModelCacheService implements JavaGlueModelCache {
 		CachedMethods(long modStamp, IMethod[] methods) {
 			this.modStamp = modStamp;
 			this.methods = methods;
+		}
+	}
+
+	private static final class CachedDocument {
+		final long modStamp;
+		final Document document;
+
+		CachedDocument(long modStamp, Document document) {
+			this.modStamp = modStamp;
+			this.document = document;
 		}
 	}
 
@@ -122,6 +140,47 @@ public class JavaGlueModelCacheService implements JavaGlueModelCache {
 			return new IMethod[0];
 		}
 		return resolveTypeMethod(getMethods(type), codeLocation);
+	}
+
+	@Override
+	public int getLineNumber(ICompilationUnit compUnit, ISourceReference annotation) throws JavaModelException {
+		Document document = getDocument(compUnit);
+		try {
+			return document.getLineOfOffset(annotation.getSourceRange().getOffset()) + 1;
+		} catch (BadLocationException e) {
+			return -1;
+		}
+	}
+
+	private Document getDocument(ICompilationUnit compUnit) {
+		IResource resource = compUnit.getResource();
+		long modStamp = resource != null ? resource.getModificationStamp() : IResource.NULL_STAMP;
+		return documentCache.compute(compUnit, (cu, existing) -> {
+			if (existing != null && existing.modStamp == modStamp) {
+				return existing;
+			}
+			long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+			Document document;
+			try {
+				document = new Document(cu.getBuffer().getContents());
+			} catch (JavaModelException e) {
+				document = new Document("");
+			}
+			if (Tracing.PERF_STEPS) {
+				long elapsed = (System.nanoTime() - start) / 1_000_000;
+				if (elapsed >= SLOW_MISS_THRESHOLD_MS) {
+					Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
+							"JavaGlueModelCache: SLOW MISS for '" + cu.getElementName() + "' - built Document in "
+									+ elapsed + "ms (modStamp=" + modStamp
+									+ ") - check for concurrent reconciler/build/DSL-support activity");
+				} else {
+					Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "JavaGlueModelCache: MISS for '"
+							+ cu.getElementName() + "' - built Document in " + elapsed + "ms (modStamp=" + modStamp
+							+ ")");
+				}
+			}
+			return new CachedDocument(modStamp, document);
+		}).document;
 	}
 
 }

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -73,9 +73,10 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 			Map<String, IType> typeBuffer = new ConcurrentHashMap<>();
 			LongAdder getMethodsNanos = new LongAdder();
 			LongAdder filterNanos = new LongAdder();
+			LongAdder lineNumberNanos = new LongAdder();
 			Collection<StepDefinition> result = steps.parallelStream()
 					.map(cucumberStep -> parseStepDefintion(cucumberStep, javaProject, typeBuffer, perf,
-							getMethodsNanos, filterNanos, remaining.split(1)))
+							getMethodsNanos, filterNanos, lineNumberNanos, remaining.split(1)))
 					.filter(Objects::nonNull).collect(Collectors.toList());
 
 			if (perf) {
@@ -84,7 +85,8 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 				Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
 						"findStepDefinitions phase breakdown (summed across all step def(s), threads run in parallel"
 								+ " so this can exceed wall time): getMethods=" + toMs(getMethodsNanos)
-								+ "ms, resolveTypeMethod=" + toMs(filterNanos) + "ms");
+								+ "ms, resolveTypeMethod=" + toMs(filterNanos) + "ms, lineNumber="
+								+ toMs(lineNumberNanos) + "ms");
 			}
 			return result;
 		} catch (OperationCanceledException e) {
@@ -94,7 +96,7 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 
 	private StepDefinition parseStepDefintion(CucumberStepDefinition cucumberStep, IJavaProject project,
 			Map<String, IType> typeBuffer, boolean perf, LongAdder getMethodsNanos, LongAdder filterNanos,
-			IProgressMonitor monitor) {
+			LongAdder lineNumberNanos, IProgressMonitor monitor) {
 		CucumberCodeLocation codeLocation = cucumberStep.getCodeLocation();
 		io.cucumber.plugin.event.StepDefinition cucumberStepDefinition = cucumberStep.getStepDefinition();
 		IType type = typeBuffer.computeIfAbsent(codeLocation.getTypeName(), typeName -> {
@@ -119,7 +121,11 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 				if (methods.length == 1) {
 					// perfect match
 					IMethod method = methods[0];
-					int lineNumber = getLineNumber(method.getCompilationUnit(), method);
+					long t2 = perf ? System.nanoTime() : 0;
+					int lineNumber = modelCache.getLineNumber(method.getCompilationUnit(), method);
+					if (perf) {
+						lineNumberNanos.add(System.nanoTime() - t2);
+					}
 					ExpressionDefinition expression = new ExpressionDefinition(cucumberStepDefinition.getPattern());
 					String id = method.getHandleIdentifier();
 					return new StepDefinition(id, JDTUtil.getMethodName(method), expression, type.getResource(),

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/JavaStepDefinitionsProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/JavaStepDefinitionsProvider.java
@@ -10,14 +10,12 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IClassFile;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMemberValuePair;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragment;
-import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
@@ -28,8 +26,6 @@ import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.SearchRequestor;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Document;
 
 import io.cucumber.eclipse.editor.EditorLogging;
 import io.cucumber.eclipse.editor.steps.IStepDefinitionsProvider;
@@ -90,22 +86,6 @@ public abstract class JavaStepDefinitionsProvider implements IStepDefinitionsPro
 		} catch (Throwable t) {
 			EditorLogging.error("JDT search failed - this may be a bug in the JDT plugin", t);
 			// if the search engine failed, skip it is a bug into the JDT plugin
-		}
-	}
-
-	/**
-	 * @param compUnit
-	 * @param annotation
-	 * @return int
-	 * @throws JavaModelException
-	 */
-	protected static int getLineNumber(ICompilationUnit compUnit, ISourceReference annotation)
-			throws JavaModelException {
-		Document document = new Document(compUnit.getBuffer().getContents());
-		try {
-			return document.getLineOfOffset(annotation.getSourceRange().getOffset()) + 1;
-		} catch (BadLocationException e) {
-			return -1;
 		}
 	}
 


### PR DESCRIPTION
JavaStepDefinitionsProvider.getLineNumber built a brand-new Document - which indexes line offsets across a file's entire source text - on every single call, with no caching. It was called once per matched step definition, so for a glue class with many step methods, the same file was fully read and re-indexed once per step just to look up individual line numbers.

Extends JavaGlueModelCache (the service added for IType.getMethods()/parameter-name caching) with getLineNumber(ICompilationUnit, ISourceReference), backed by a Map<ICompilationUnit, Document> cache using the same modification-stamp invalidation scheme as getMethods(): a cached Document is reused only while the compilation unit's underlying resource modStamp is unchanged, otherwise it's rebuilt and replaced, so an edited file is picked up on the very next lookup.

Also adds a dedicated slow-outlier trace line, separate from the routine per-miss line: if a single Document (re)build takes >= 200ms, it's logged with the specific file, duration, and a pointer at concurrent reconciler/build/DSL-support activity as the likely cause, rather than only ever showing up as an unexplained spike in the summed per-invocation total.

CucumberStepDefinitionProvider now calls modelCache.getLineNumber(...) instead of the inherited static helper, with its own lineNumberNanos phase timer added to the existing getMethods/ resolveTypeMethod phase-breakdown trace line, so cache effectiveness is directly measurable the same way the other two caches already are.

The now-fully-dead uncached JavaStepDefinitionsProvider.getLineNumber is removed - it had exactly one caller (CucumberStepDefinitionProvider, the sole subclass of this abstract base), and once that caller goes through the cache there's no remaining reason to keep an uncached duplicate around, consistent with how the equivalent uncached resolveMethod/resolveTypeMethod family was removed from JDTUtil in a prior change once all of its callers were migrated.

Measured impact: on the reproducer used throughout this investigation (one glue class with 92 step methods), this phase went from an unmeasured-but-clearly-large per-invocation cost to consistently negligible - low single-digit milliseconds - on both cold and warm invocations, confirmed via the existing lineNumber phase timer.
