### PR TITLE
perf: cache Javadoc HTML, and defer computing it until a proposal is inspected

### DIFF
--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/StorageHelper.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/StorageHelper.java
@@ -116,7 +116,7 @@ public class StorageHelper {
 		ExpressionDefinition expression = new ExpressionDefinition(expStr, expLang);
 		// FIXME
 		return new StepDefinition(id, label, expression, resource, line, sourceName, packageName, new StepParameter[0],
-				null);
+				(String) null);
 	}
 
 }

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/contentassist/CucumberTemplates.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/contentassist/CucumberTemplates.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -141,7 +142,7 @@ public class CucumberTemplates {
 
 										return new CucumberTemplateProposal(stepProposal.getTemplate(), ctx, region,
 												icon, stepProposal.relevance,
-												stepProposal.getStepDefinition().getDescription());
+												stepProposal.getStepDefinition()::getDescription);
 									}).sorted(RELEVANCE_ORDER).toArray(ICompletionProposal[]::new);
 							return proposals;
 						}
@@ -174,27 +175,55 @@ public class CucumberTemplates {
 
 	private static final class CucumberTemplateProposal extends TemplateProposal {
 
-		private String description;
+		private volatile Supplier<String> descriptionSupplier;
+		private volatile String description;
+		private volatile boolean descriptionResolved;
 
 		public CucumberTemplateProposal(Template template, TemplateContext context, IRegion region, Image image,
-				int relevance, String description) {
+				int relevance, Supplier<String> descriptionSupplier) {
 			super(template, context, region, image, relevance);
-			this.description = description;
-			if (description != null && description.startsWith("<html")) {
-				setInformationControlCreator(new IInformationControlCreator() {
+			this.descriptionSupplier = descriptionSupplier;
+		}
+
+		/**
+		 * Resolves the description on first use and memoizes it - deferred this far so an expensive
+		 * description (e.g. rendered Javadoc) is only ever computed for a proposal the user actually
+		 * inspects (JFace queries this lazily for the currently highlighted proposal), not for every
+		 * candidate produced by {@link #computeTemplateProposals}.
+		 */
+		private String resolveDescription() {
+			if (!descriptionResolved) {
+				synchronized (this) {
+					if (!descriptionResolved) {
+						description = descriptionSupplier == null ? null : descriptionSupplier.get();
+						descriptionSupplier = null;
+						descriptionResolved = true;
+					}
+				}
+			}
+			return description;
+		}
+
+		@Override
+		public IInformationControlCreator getInformationControlCreator() {
+			String resolvedDescription = resolveDescription();
+			if (resolvedDescription != null && resolvedDescription.startsWith("<html")) {
+				return new IInformationControlCreator() {
 
 					@Override
 					public IInformationControl createInformationControl(Shell parent) {
-						return new HtmlInformationControl(parent, description);
+						return new HtmlInformationControl(parent, resolvedDescription);
 					}
-				});
+				};
 			}
+			return super.getInformationControlCreator();
 		}
 
 		@Override
 		public String getAdditionalProposalInfo() {
-			if (description != null) {
-				return description;
+			String resolvedDescription = resolveDescription();
+			if (resolvedDescription != null) {
+				return resolvedDescription;
 			}
 			return getTemplate().getDescription();
 		}

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/steps/StepDefinition.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/steps/StepDefinition.java
@@ -2,8 +2,11 @@ package io.cucumber.eclipse.editor.steps;
 
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.eclipse.core.resources.IResource;
+
+import io.cucumber.eclipse.editor.Tracing;
 
 /**
  * A parse stepdefinition that relates either to a source file or a classpath
@@ -31,11 +34,13 @@ public final class StepDefinition {
 	private final String packageName;
 	private final String id;
 	private StepParameter[] parameters;
-	private String description;
+	private volatile Supplier<String> descriptionSupplier;
+	private volatile String description;
+	private volatile boolean descriptionResolved;
 
 	/**
 	 * Creates a new {@link StepDefinition}
-	 * 
+	 *
 	 * @param id             the persistent id of this step, this might be used by
 	 *                       plugins to uniquely identify a step across others in
 	 *                       the workspace
@@ -52,6 +57,18 @@ public final class StepDefinition {
 	 */
 	public StepDefinition(String id, String label, ExpressionDefinition expression, IResource source, int lineNumber,
 			String sourceName, String packageName, StepParameter[] parameters, String description) {
+		this(id, label, expression, source, lineNumber, sourceName, packageName, parameters, () -> description);
+	}
+
+	/**
+	 * Same as {@link #StepDefinition(String, String, ExpressionDefinition, IResource, int, String,
+	 * String, StepParameter[], String)} but the description is resolved lazily, on the first actual
+	 * call to {@link #getDescription()}, and memoized from then on - useful when computing the
+	 * description upfront (e.g. rendering Javadoc) is expensive and most step definitions never have
+	 * their description looked at.
+	 */
+	public StepDefinition(String id, String label, ExpressionDefinition expression, IResource source, int lineNumber,
+			String sourceName, String packageName, StepParameter[] parameters, Supplier<String> descriptionSupplier) {
 		this.id = id;
 		this.label = label;
 		this.expression = expression;
@@ -59,7 +76,7 @@ public final class StepDefinition {
 		this.lineNumber = lineNumber;
 		this.sourceName = sourceName;
 		this.packageName = packageName;
-		this.description = description;
+		this.descriptionSupplier = descriptionSupplier;
 		this.parameters = Objects.requireNonNullElseGet(parameters, () -> new StepParameter[0]);
 	}
 
@@ -87,6 +104,21 @@ public final class StepDefinition {
 	}
 
 	public String getDescription() {
+		if (!descriptionResolved) {
+			synchronized (this) {
+				if (!descriptionResolved) {
+					long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+					description = descriptionSupplier == null ? null : descriptionSupplier.get();
+					if (Tracing.PERF_STEPS) {
+						Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "StepDefinition.getDescription(): lazily "
+								+ "computed description for '" + id + "' in " + ((System.nanoTime() - start) / 1_000_000)
+								+ "ms");
+					}
+					descriptionSupplier = null;
+					descriptionResolved = true;
+				}
+			}
+		}
 		return description;
 	}
 

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/JDTUtil.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/JDTUtil.java
@@ -47,19 +47,13 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
-import org.eclipse.jdt.internal.ui.text.javadoc.JavadocContentAccess2;
 import org.eclipse.jdt.launching.JavaRuntime;
-import org.eclipse.jface.internal.text.html.HTMLPrinter;
-import org.eclipse.jface.resource.ColorRegistry;
-import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.swt.graphics.RGB;
 
 import io.cucumber.eclipse.editor.EditorLogging;
 import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.java.steps.JavaStepDefinitionsProvider;
 
-@SuppressWarnings("restriction")
 public class JDTUtil {
 
 	private JDTUtil() {
@@ -239,23 +233,6 @@ public class JDTUtil {
 		name.append(")");
 
 		return name.toString();
-	}
-
-	public static String getJavadoc(IMethod method) {
-		try {
-			String content = JavadocContentAccess2.getHTMLContent(method, true);
-			if (content != null) {
-				StringBuilder buffer = new StringBuilder(content);
-				ColorRegistry registry = JFaceResources.getColorRegistry();
-				RGB fgRGB = registry.getRGB("org.eclipse.jdt.ui.Javadoc.foregroundColor"); //$NON-NLS-1$
-				RGB bgRGB = registry.getRGB("org.eclipse.jdt.ui.Javadoc.backgroundColor"); //$NON-NLS-1$
-				HTMLPrinter.insertPageProlog(buffer, 0, fgRGB, bgRGB, "");
-				HTMLPrinter.addPageEpilog(buffer);
-				return buffer.toString();
-			}
-		} catch (CoreException e) {
-		}
-		return null;
 	}
 
 	public static Collection<ICompilationUnit> getGlueSources(IJavaProject javaProject, IProgressMonitor monitor)

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCache.java
@@ -55,4 +55,15 @@ public interface JavaGlueModelCache {
 	 */
 	int getLineNumber(ICompilationUnit compUnit, ISourceReference annotation) throws JavaModelException;
 
+	/**
+	 * @param method the method to render Javadoc HTML for
+	 * @return the rendered Javadoc HTML for {@code method} (styled for display, or {@code null} if
+	 *         it has none / it couldn't be rendered), cached until {@code method}'s underlying
+	 *         source changes. Unlike {@link #getParameterNames(IMethod)}, invalidation is based on
+	 *         the source file's modification stamp rather than {@link IMethod} handle identity: a
+	 *         Javadoc comment can change without the method's signature - and therefore its handle -
+	 *         changing at all.
+	 */
+	String getJavadoc(IMethod method);
+
 }

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/cache/JavaGlueModelCacheService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -12,14 +13,20 @@ import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.ui.text.javadoc.JavadocContentAccess2;
+import org.eclipse.jface.internal.text.html.HTMLPrinter;
+import org.eclipse.jface.resource.ColorRegistry;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
+import org.eclipse.swt.graphics.RGB;
 import org.osgi.service.component.annotations.Component;
 
 import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.java.JDTUtil;
 import io.cucumber.eclipse.java.plugins.CucumberCodeLocation;
 
+@SuppressWarnings("restriction")
 @Component(service = JavaGlueModelCache.class)
 public class JavaGlueModelCacheService implements JavaGlueModelCache {
 
@@ -29,6 +36,7 @@ public class JavaGlueModelCacheService implements JavaGlueModelCache {
 	private final Map<IType, CachedMethods> cache = new ConcurrentHashMap<>();
 	private final Map<IMethod, String[]> parameterNamesCache = new ConcurrentHashMap<>();
 	private final Map<ICompilationUnit, CachedDocument> documentCache = new ConcurrentHashMap<>();
+	private final Map<IMethod, CachedJavadoc> javadocCache = new ConcurrentHashMap<>();
 
 	private static final class CachedMethods {
 		final long modStamp;
@@ -47,6 +55,16 @@ public class JavaGlueModelCacheService implements JavaGlueModelCache {
 		CachedDocument(long modStamp, Document document) {
 			this.modStamp = modStamp;
 			this.document = document;
+		}
+	}
+
+	private static final class CachedJavadoc {
+		final long modStamp;
+		final String javadoc;
+
+		CachedJavadoc(long modStamp, String javadoc) {
+			this.modStamp = modStamp;
+			this.javadoc = javadoc;
 		}
 	}
 
@@ -181,6 +199,42 @@ public class JavaGlueModelCacheService implements JavaGlueModelCache {
 			}
 			return new CachedDocument(modStamp, document);
 		}).document;
+	}
+
+	@Override
+	public String getJavadoc(IMethod method) {
+		IResource resource = method.getResource();
+		long modStamp = resource != null ? resource.getModificationStamp() : IResource.NULL_STAMP;
+		return javadocCache.compute(method, (m, existing) -> {
+			if (existing != null && existing.modStamp == modStamp) {
+				return existing;
+			}
+			long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+			String javadoc = renderJavadoc(m);
+			if (Tracing.PERF_STEPS) {
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "JavaGlueModelCache: MISS for javadoc of '"
+						+ m.getElementName() + "' - rendered in " + ((System.nanoTime() - start) / 1_000_000)
+						+ "ms (modStamp=" + modStamp + ")");
+			}
+			return new CachedJavadoc(modStamp, javadoc);
+		}).javadoc;
+	}
+
+	private static String renderJavadoc(IMethod method) {
+		try {
+			String content = JavadocContentAccess2.getHTMLContent(method, true);
+			if (content != null) {
+				StringBuilder buffer = new StringBuilder(content);
+				ColorRegistry registry = JFaceResources.getColorRegistry();
+				RGB fgRGB = registry.getRGB("org.eclipse.jdt.ui.Javadoc.foregroundColor"); //$NON-NLS-1$
+				RGB bgRGB = registry.getRGB("org.eclipse.jdt.ui.Javadoc.backgroundColor"); //$NON-NLS-1$
+				HTMLPrinter.insertPageProlog(buffer, 0, fgRGB, bgRGB, "");
+				HTMLPrinter.addPageEpilog(buffer);
+				return buffer.toString();
+			}
+		} catch (CoreException e) {
+		}
+		return null;
 	}
 
 }

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -86,7 +86,9 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 						"findStepDefinitions phase breakdown (summed across all step def(s), threads run in parallel"
 								+ " so this can exceed wall time): getMethods=" + toMs(getMethodsNanos)
 								+ "ms, resolveTypeMethod=" + toMs(filterNanos) + "ms, lineNumber="
-								+ toMs(lineNumberNanos) + "ms");
+								+ toMs(lineNumberNanos)
+								+ "ms; javadoc is now computed lazily on first getDescription() call - see"
+								+ " JavaGlueModelCache's own trace line for its render/cache-hit timing");
 			}
 			return result;
 		} catch (OperationCanceledException e) {
@@ -130,14 +132,14 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 					String id = method.getHandleIdentifier();
 					return new StepDefinition(id, JDTUtil.getMethodName(method), expression, type.getResource(),
 							lineNumber, method.getElementName(), type.getPackageFragment().getElementName(),
-							getParameter(method), JDTUtil.getJavadoc(method));
+							getParameter(method), () -> modelCache.getJavadoc(method));
 				}
 			} catch (JavaModelException e) {
 			}
 		}
 		return new StepDefinition(cucumberStepDefinition.getLocation(), StepDefinition.NO_LABEL,
 				new ExpressionDefinition(cucumberStepDefinition.getPattern()), null, -1,
-				cucumberStepDefinition.getLocation(), "", null, null);
+				cucumberStepDefinition.getLocation(), "", null, (String) null);
 	}
 
 	private static long toMs(LongAdder nanos) {


### PR DESCRIPTION
JDTUtil.getJavadoc(IMethod) rendered a step definition's Javadoc as styled HTML (JavadocContentAccess2.getHTMLContent plus JFace color-registry/page-prolog decoration) from scratch on every content-assist invocation, for every candidate step definition, with no caching and no laziness. This was the single most expensive per-item operation found during the original investigation of this call chain (~339ms average per call, ~140s summed across 414 candidates in one invocation) - and only a handful of those candidates are ever actually shown to the user per invocation, since JFace's completion popup only queries additional info for the currently highlighted proposal.

Two changes, needed together (caching alone still pays the cost once per method per session; laziness alone gets forced eagerly by whichever layer above it still calls getDescription() eagerly):

1. Cache the render in JavaGlueModelCache (the service already caching getMethods()/parameter names/line-number Documents), via new getJavadoc(IMethod), backed by a Map<IMethod, CachedJavadoc>. Invalidation here is deliberately different from getParameterNames: a Javadoc comment can change without the method's signature - and therefore its IMethod handle - changing at all, so handle-identity isn't a safe invalidation signal the way it is for parameter names. This cache uses the same modification-stamp scheme as getMethods()/getLineNumber() instead. A null result (no doc comment, or a render failure) is cached correctly too, since every outcome is wrapped in a CachedJavadoc record rather than relying on a null-check to mean "not yet computed". Since getJavadoc's only caller is now the cache itself, the actual rendering implementation moved from JDTUtil into JavaGlueModelCacheService (as private renderJavadoc, called only on a miss) - the same relocation already applied to resolveMethod/resolveTypeMethod and getLineNumber once their callers were fully migrated. JDTUtil no longer needs the org.eclipse.jdt.internal.ui.text.javadoc / org.eclipse.jface.internal.text.html imports or its class-level @SuppressWarnings("restriction").

2. Defer the lookup entirely until something actually asks for a specific proposal's description, so most renders never happen at all on a cold cache:
   - StepDefinition (editor bundle): the eager String description constructor now wraps its value in a Supplier<String> and delegates to a new Supplier-taking constructor. getDescription() resolves the supplier lazily on first call, memoizes the result (double-checked locking), then drops the supplier reference so anything it captured can be garbage collected. Added a Tracing.PERF_STEPS-guarded trace line reporting how long each lazy resolution took, to make it directly measurable how many step definitions actually needed their description computed.
   - CucumberTemplates.CucumberTemplateProposal: this is the layer that actually determines whether laziness helps - it was still calling stepProposal.getStepDefinition().getDescription() eagerly while building every proposal, and its constructor took an already-resolved description string, registering an HtmlInformationControl for it immediately. Both are fixed together: the call site now passes the unevaluated method reference stepProposal.getStepDefinition()::getDescription, and the proposal takes a Supplier<String> with the same lazy-and-memoize pattern. The HTML-vs-plain-text decision and HtmlInformationControl registration move out of the constructor into an override of getInformationControlCreator(), which JFace's completion popup queries lazily, only for the currently highlighted proposal (falling back to super.getInformationControlCreator() when the resolved text isn't HTML). getAdditionalProposalInfo() resolves the same memoized value instead of reading a pre-set field.
   - Compile-hazard: introducing the Supplier<String> overload made two existing call sites passing a literal null for that parameter ambiguous to javac (CucumberStepDefinitionProvider's no-glue-match fallback, StorageHelper's deserialization path) - both now cast explicitly to (String) null. Grepped every new StepDefinition(/new CucumberTemplateProposal( call site afterward to confirm no others exist.
   - CucumberStepDefinitionProvider's hot path now passes () -> modelCache.getJavadoc(method) instead of calling it eagerly. Removed the javadocNanos phase timer, since with this change the call may happen much later on a different thread - a timer summed inside findStepDefinitions would be meaningless. The phase-breakdown trace line now points at the two lines with real signal instead: JavaGlueModelCache's own per-miss trace, and StepDefinition's new lazy-resolution trace.

StepDefinition's equals()/hashCode() never reference description, and CucumberTemplateProposal has no equals()/hashCode() override at all - no behavioral risk from making it lazy in either class. No MANIFEST.MF/OSGI-INF changes needed anywhere - this extends the component already registered for the getMethods() cache, and the restricted-API classes were already reachable from this bundle via its existing Require-Bundle entries regardless of which package uses them.

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
