### PR TITLE
perf: defer StepParameter resolution until a proposal's parameters are actually read

### DIFF
--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/StorageHelper.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/StorageHelper.java
@@ -115,8 +115,8 @@ public class StorageHelper {
 		IResource resource = ResourceHelper.find(sourceRef);
 		ExpressionDefinition expression = new ExpressionDefinition(expStr, expLang);
 		// FIXME
-		return new StepDefinition(id, label, expression, resource, line, sourceName, packageName, new StepParameter[0],
-				(String) null);
+		return new StepDefinition(id, label, expression, resource, line, sourceName, packageName,
+				() -> new StepParameter[0], (String) null);
 	}
 
 }

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/steps/StepDefinition.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/steps/StepDefinition.java
@@ -33,7 +33,9 @@ public final class StepDefinition {
 	private final String sourceName;
 	private final String packageName;
 	private final String id;
-	private StepParameter[] parameters;
+	private volatile Supplier<StepParameter[]> parametersSupplier;
+	private volatile StepParameter[] parameters;
+	private volatile boolean parametersResolved;
 	private volatile Supplier<String> descriptionSupplier;
 	private volatile String description;
 	private volatile boolean descriptionResolved;
@@ -53,22 +55,27 @@ public final class StepDefinition {
 	 * @param sourceName     the name of the source, if not given, the name of te
 	 *                       resource might be used
 	 * @param packageName    the packagename of the source
-	 * @param parameterNames the parameter names of the corresponding method
+	 * @param parametersSupplier resolves the parameters of the corresponding method, lazily on the
+	 *                       first actual call to {@link #getParameters()} and memoized from then on -
+	 *                       useful when resolving parameter types (e.g. enum constant values) upfront
+	 *                       is expensive and most step definitions never have their parameters looked
+	 *                       at (only actually needed when a proposal for this step is inserted).
 	 */
 	public StepDefinition(String id, String label, ExpressionDefinition expression, IResource source, int lineNumber,
-			String sourceName, String packageName, StepParameter[] parameters, String description) {
-		this(id, label, expression, source, lineNumber, sourceName, packageName, parameters, () -> description);
+			String sourceName, String packageName, Supplier<StepParameter[]> parametersSupplier, String description) {
+		this(id, label, expression, source, lineNumber, sourceName, packageName, parametersSupplier, () -> description);
 	}
 
 	/**
 	 * Same as {@link #StepDefinition(String, String, ExpressionDefinition, IResource, int, String,
-	 * String, StepParameter[], String)} but the description is resolved lazily, on the first actual
+	 * String, Supplier, String)} but the description is resolved lazily too, on the first actual
 	 * call to {@link #getDescription()}, and memoized from then on - useful when computing the
 	 * description upfront (e.g. rendering Javadoc) is expensive and most step definitions never have
 	 * their description looked at.
 	 */
 	public StepDefinition(String id, String label, ExpressionDefinition expression, IResource source, int lineNumber,
-			String sourceName, String packageName, StepParameter[] parameters, Supplier<String> descriptionSupplier) {
+			String sourceName, String packageName, Supplier<StepParameter[]> parametersSupplier,
+			Supplier<String> descriptionSupplier) {
 		this.id = id;
 		this.label = label;
 		this.expression = expression;
@@ -76,11 +83,27 @@ public final class StepDefinition {
 		this.lineNumber = lineNumber;
 		this.sourceName = sourceName;
 		this.packageName = packageName;
+		this.parametersSupplier = parametersSupplier;
 		this.descriptionSupplier = descriptionSupplier;
-		this.parameters = Objects.requireNonNullElseGet(parameters, () -> new StepParameter[0]);
 	}
 
 	public StepParameter[] getParameters() {
+		if (!parametersResolved) {
+			synchronized (this) {
+				if (!parametersResolved) {
+					long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+					StepParameter[] resolved = parametersSupplier == null ? null : parametersSupplier.get();
+					parameters = Objects.requireNonNullElseGet(resolved, () -> new StepParameter[0]);
+					if (Tracing.PERF_STEPS) {
+						Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "StepDefinition.getParameters(): lazily "
+								+ "computed " + parameters.length + " parameter(s) for '" + id + "' in "
+								+ ((System.nanoTime() - start) / 1_000_000) + "ms");
+					}
+					parametersSupplier = null;
+					parametersResolved = true;
+				}
+			}
+		}
 		return parameters;
 	}
 

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 import io.cucumber.eclipse.editor.steps.ExpressionDefinition;
 import io.cucumber.eclipse.editor.steps.IStepDefinitionsProvider;
 import io.cucumber.eclipse.editor.steps.StepDefinition;
+import io.cucumber.eclipse.editor.steps.StepParameter;
 import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.java.JDTUtil;
 import io.cucumber.eclipse.java.cache.JavaGlueModelCache;
@@ -132,7 +133,13 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 					String id = method.getHandleIdentifier();
 					return new StepDefinition(id, JDTUtil.getMethodName(method), expression, type.getResource(),
 							lineNumber, method.getElementName(), type.getPackageFragment().getElementName(),
-							getParameter(method), () -> modelCache.getJavadoc(method));
+							() -> {
+								try {
+									return getParameter(method);
+								} catch (JavaModelException e) {
+									return new StepParameter[0];
+								}
+							}, () -> modelCache.getJavadoc(method));
 				}
 			} catch (JavaModelException e) {
 			}


### PR DESCRIPTION
JavaStepDefinitionsProvider.getParameter builds a StepDefinition's StepParameter[] eagerly for every candidate on every findStepDefinitions() invocation, resolving each parameter's declaring type via JDTUtil.resolveTypeWithRetry to detect enum-valued parameters and populate their constant choices. Unlike getMethods/getParameterNames/getJavadoc, this call was never routed through JavaGlueModelCache at all - it's a raw, uncached JDT call repeated in full on every invocation, cold or warm.

Tracing the only consumer of StepDefinition.getParameters() (CucumberExpressionParserSupport.evaluate, invoked by JFace's DocumentTemplateContext.evaluate(Template) only when a template proposal is actually inserted, not when the proposal list is built or displayed) shows this is exactly the same shape of problem the Javadoc caching/laziness work already solved: expensive per-candidate resolution that's only ever needed for the one proposal a user actually accepts, computed for all of them anyway.

Applies the same Supplier-based lazy-and-memoize pattern used for StepDefinition's description:
- StepDefinition's parameters field is now backed by a Supplier<StepParameter[]>, resolved on first call to getParameters() (double-checked locking) and memoized from then on, with a Tracing.PERF_STEPS-guarded trace line reporting how many parameters were resolved and how long it took - the same visibility pattern already used for lazy description resolution.
- CucumberStepDefinitionProvider's hot path now passes a deferred supplier instead of calling getParameter(method) eagerly. Since getParameter declares a checked JavaModelException that Supplier.get() can't propagate, the supplier catches it and returns an empty StepParameter[] - matching how a resolution failure already degrades gracefully elsewhere in this codebase, and actually an improvement over the previous behavior: a JavaModelException while resolving parameters used to be caught by parseStepDefintion's outer try/catch and downgrade the *entire* step to the unmatched/no-source fallback (no label, no navigation, no description either) - now a parameter resolution failure only affects that one lazy accessor, and only if/when it's actually called.
- StorageHelper's deserialization path and the "no match" fallback in CucumberStepDefinitionProvider updated to pass a trivial supplier/null respectively, matching the new constructor signature.

equals()/hashCode() on StepDefinition never reference the parameters field - no behavioral risk from making it lazy.


