### PR TITLE
perf: defer JDT method resolution out of the content-assist listing path

### DIFF
--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/StorageHelper.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/StorageHelper.java
@@ -114,9 +114,10 @@ public class StorageHelper {
 		String sourceRef = (String) in.readObject();
 		IResource resource = ResourceHelper.find(sourceRef);
 		ExpressionDefinition expression = new ExpressionDefinition(expStr, expLang);
+		StepDefinition.ResolvedLocation location = new StepDefinition.ResolvedLocation(resource, line, sourceName,
+				packageName);
 		// FIXME
-		return new StepDefinition(id, label, expression, resource, line, sourceName, packageName,
-				() -> new StepParameter[0], (String) null);
+		return new StepDefinition(id, label, expression, () -> location, () -> new StepParameter[0], (String) null);
 	}
 
 }

--- a/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/steps/StepDefinition.java
+++ b/io.cucumber.eclipse.editor/src/io/cucumber/eclipse/editor/steps/StepDefinition.java
@@ -11,7 +11,7 @@ import io.cucumber.eclipse.editor.Tracing;
 /**
  * A parse stepdefinition that relates either to a source file or a classpath
  * item
- * 
+ *
  * @author Christoph Läubrich
  *
  */
@@ -25,17 +25,57 @@ public final class StepDefinition {
 	public static final Comparator<? super StepDefinition> EXPRESSION_TEXT_ORDER = (s1, s2) -> s1.getExpression().getText()
 			.compareToIgnoreCase(s2.getExpression().getText());
 
-	private final IResource source;
-	private final int lineNumber;
+	/**
+	 * The location-derived attributes of a {@link StepDefinition} - grouped together since they're
+	 * all resolved from the same underlying source lookup, not independently.
+	 */
+	public static final class ResolvedLocation {
+
+		public static final ResolvedLocation NONE = new ResolvedLocation(NO_SOURCE, NO_LINE_NUMBER, NO_SOURCE_NAME,
+				NO_PACKAGE_NAME);
+
+		private final IResource source;
+		private final int lineNumber;
+		private final String sourceName;
+		private final String packageName;
+
+		public ResolvedLocation(IResource source, int lineNumber, String sourceName, String packageName) {
+			this.source = source;
+			this.lineNumber = lineNumber;
+			this.sourceName = sourceName;
+			this.packageName = packageName;
+		}
+
+		public IResource getSource() {
+			return source;
+		}
+
+		public int getLineNumber() {
+			return lineNumber;
+		}
+
+		public String getSourceName() {
+			return sourceName;
+		}
+
+		public String getPackageName() {
+			return packageName;
+		}
+
+	}
+
 	private final ExpressionDefinition expression;
 	private final String label;
-
-	private final String sourceName;
-	private final String packageName;
 	private final String id;
+
+	private volatile Supplier<ResolvedLocation> locationSupplier;
+	private volatile ResolvedLocation location;
+	private volatile boolean locationResolved;
+
 	private volatile Supplier<StepParameter[]> parametersSupplier;
 	private volatile StepParameter[] parameters;
 	private volatile boolean parametersResolved;
+
 	private volatile Supplier<String> descriptionSupplier;
 	private volatile String description;
 	private volatile boolean descriptionResolved;
@@ -43,48 +83,60 @@ public final class StepDefinition {
 	/**
 	 * Creates a new {@link StepDefinition}
 	 *
-	 * @param id             the persistent id of this step, this might be used by
-	 *                       plugins to uniquely identify a step across others in
-	 *                       the workspace
-	 * @param label          a userfriendly label
-	 * @param expression     the expresion that this step contains
-	 * @param source         the source where this step is created from
-	 * @param lineNumber     an optional line limber where in the resource the step
-	 *                       was found use {@link #NO_LINE_NUMBER} in case where no
-	 *                       is available
-	 * @param sourceName     the name of the source, if not given, the name of te
-	 *                       resource might be used
-	 * @param packageName    the packagename of the source
+	 * @param id                 the persistent id of this step, this might be used by plugins to
+	 *                           uniquely identify a step across others in the workspace
+	 * @param label              a userfriendly label
+	 * @param expression         the expresion that this step contains
+	 * @param locationSupplier   resolves this step's source/line-number/source-name/package-name,
+	 *                           lazily on the first actual call to any of {@link #getSource()},
+	 *                           {@link #getLineNumber()}, {@link #getSourceName()},
+	 *                           {@link #getPackageName()}, and memoized from then on - useful when
+	 *                           computing this upfront (e.g. resolving a JDT method) is expensive and
+	 *                           most step definitions never have their location looked at
 	 * @param parametersSupplier resolves the parameters of the corresponding method, lazily on the
-	 *                       first actual call to {@link #getParameters()} and memoized from then on -
-	 *                       useful when resolving parameter types (e.g. enum constant values) upfront
-	 *                       is expensive and most step definitions never have their parameters looked
-	 *                       at (only actually needed when a proposal for this step is inserted).
+	 *                           first actual call to {@link #getParameters()} and memoized from then
+	 *                           on - useful when resolving parameter types (e.g. enum constant
+	 *                           values) upfront is expensive and most step definitions never have
+	 *                           their parameters looked at (only actually needed when a proposal for
+	 *                           this step is inserted)
 	 */
-	public StepDefinition(String id, String label, ExpressionDefinition expression, IResource source, int lineNumber,
-			String sourceName, String packageName, Supplier<StepParameter[]> parametersSupplier, String description) {
-		this(id, label, expression, source, lineNumber, sourceName, packageName, parametersSupplier, () -> description);
+	public StepDefinition(String id, String label, ExpressionDefinition expression,
+			Supplier<ResolvedLocation> locationSupplier, Supplier<StepParameter[]> parametersSupplier,
+			String description) {
+		this(id, label, expression, locationSupplier, parametersSupplier, () -> description);
 	}
 
 	/**
-	 * Same as {@link #StepDefinition(String, String, ExpressionDefinition, IResource, int, String,
-	 * String, Supplier, String)} but the description is resolved lazily too, on the first actual
-	 * call to {@link #getDescription()}, and memoized from then on - useful when computing the
-	 * description upfront (e.g. rendering Javadoc) is expensive and most step definitions never have
-	 * their description looked at.
+	 * Same as {@link #StepDefinition(String, String, ExpressionDefinition, Supplier, Supplier,
+	 * String)} but the description is resolved lazily too, on the first actual call to
+	 * {@link #getDescription()}, and memoized from then on - useful when computing the description
+	 * upfront (e.g. rendering Javadoc) is expensive and most step definitions never have their
+	 * description looked at.
 	 */
-	public StepDefinition(String id, String label, ExpressionDefinition expression, IResource source, int lineNumber,
-			String sourceName, String packageName, Supplier<StepParameter[]> parametersSupplier,
+	public StepDefinition(String id, String label, ExpressionDefinition expression,
+			Supplier<ResolvedLocation> locationSupplier, Supplier<StepParameter[]> parametersSupplier,
 			Supplier<String> descriptionSupplier) {
 		this.id = id;
 		this.label = label;
 		this.expression = expression;
-		this.source = source;
-		this.lineNumber = lineNumber;
-		this.sourceName = sourceName;
-		this.packageName = packageName;
+		this.locationSupplier = locationSupplier;
 		this.parametersSupplier = parametersSupplier;
 		this.descriptionSupplier = descriptionSupplier;
+	}
+
+	private ResolvedLocation resolveLocation() {
+		if (!locationResolved) {
+			synchronized (this) {
+				if (!locationResolved) {
+					Supplier<ResolvedLocation> supplier = locationSupplier;
+					location = Objects.requireNonNullElse(supplier == null ? null : supplier.get(),
+							ResolvedLocation.NONE);
+					locationSupplier = null;
+					locationResolved = true;
+				}
+			}
+		}
+		return location;
 	}
 
 	public StepParameter[] getParameters() {
@@ -108,22 +160,24 @@ public final class StepDefinition {
 	}
 
 	public IResource getSource() {
-		return source;
+		return resolveLocation().getSource();
 	}
 
 	public int getLineNumber() {
-		return lineNumber;
+		return resolveLocation().getLineNumber();
 	}
 
 	public String getSourceName() {
-		if (sourceName == null && source != null) {
-			return source.getName();
+		ResolvedLocation resolved = resolveLocation();
+		String sourceName = resolved.getSourceName();
+		if (sourceName == null && resolved.getSource() != null) {
+			return resolved.getSource().getName();
 		}
 		return sourceName;
 	}
 
 	public String getPackageName() {
-		return packageName;
+		return resolveLocation().getPackageName();
 	}
 
 	public String getDescription() {
@@ -146,7 +200,7 @@ public final class StepDefinition {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return the id to identify this step in a persitent manner
 	 */
 	public String getId() {
@@ -155,13 +209,15 @@ public final class StepDefinition {
 
 	public String getLabel() {
 		if (label == null) {
-			return getSourceName() + ":" + this.lineNumber;
+			return getSourceName() + ":" + getLineNumber();
 		}
 		return label;
 	}
 
 	@Override
 	public String toString() {
+		IResource source = getSource();
+		int lineNumber = getLineNumber();
 
 		// For Steps from Current-Project
 		if (lineNumber != 0)
@@ -169,7 +225,8 @@ public final class StepDefinition {
 
 		// For Steps From External-ClassPath JAR
 		else
-			return "Step [text=" + getExpression() + ", source=" + sourceName + ", package=" + packageName + "]";
+			return "Step [text=" + getExpression() + ", source=" + getSourceName() + ", package=" + getPackageName()
+					+ "]";
 	}
 
 	public ExpressionDefinition getExpression() {
@@ -183,10 +240,6 @@ public final class StepDefinition {
 		result = prime * result + ((expression == null) ? 0 : expression.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((label == null) ? 0 : label.hashCode());
-		result = prime * result + lineNumber;
-		result = prime * result + ((packageName == null) ? 0 : packageName.hashCode());
-		result = prime * result + ((source == null) ? 0 : source.hashCode());
-		result = prime * result + ((sourceName == null) ? 0 : sourceName.hashCode());
 		return result;
 	}
 
@@ -213,23 +266,6 @@ public final class StepDefinition {
 			if (other.label != null)
 				return false;
 		} else if (!label.equals(other.label))
-			return false;
-		if (lineNumber != other.lineNumber)
-			return false;
-		if (packageName == null) {
-			if (other.packageName != null)
-				return false;
-		} else if (!packageName.equals(other.packageName))
-			return false;
-		if (source == null) {
-			if (other.source != null)
-				return false;
-		} else if (!source.equals(other.source))
-			return false;
-		if (sourceName == null) {
-			if (other.sourceName != null)
-				return false;
-		} else if (!sourceName.equals(other.sourceName))
 			return false;
 		return true;
 	}

--- a/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
+++ b/io.cucumber.eclipse.java/src/io/cucumber/eclipse/java/steps/CucumberStepDefinitionProvider.java
@@ -4,16 +4,13 @@ import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
@@ -27,6 +24,7 @@ import org.osgi.service.component.annotations.Reference;
 import io.cucumber.eclipse.editor.steps.ExpressionDefinition;
 import io.cucumber.eclipse.editor.steps.IStepDefinitionsProvider;
 import io.cucumber.eclipse.editor.steps.StepDefinition;
+import io.cucumber.eclipse.editor.steps.StepDefinition.ResolvedLocation;
 import io.cucumber.eclipse.editor.steps.StepParameter;
 import io.cucumber.eclipse.editor.Tracing;
 import io.cucumber.eclipse.java.JDTUtil;
@@ -60,36 +58,28 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 			IProgressMonitor monitor) throws CoreException {
 		try {
 			IJavaProject javaProject = JDTUtil.getJavaProject(resource);
-			SubMonitor subMonitor = SubMonitor.convert(monitor, "Searching Java Glue Code steps", 200);
 			Collection<CucumberStepDefinition> steps = javaValidator.getAvailableSteps(viewer.getDocument());
 
 			boolean perf = Tracing.PERF_STEPS;
 			long start = perf ? System.currentTimeMillis() : 0;
 			if (perf) {
-				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "findStepDefinitions: resolving "
-						+ steps.size() + " step def(s) via JDT for " + resource.getName());
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
+						"findStepDefinitions: building " + steps.size() + " step definition(s) for "
+								+ resource.getName() + " - JDT resolution is deferred until a proposal's"
+								+ " description/parameters/location is actually requested; see"
+								+ " LazyStepMethod's own trace line for if/when that happens");
 			}
 
-			SubMonitor remaining = subMonitor.setWorkRemaining(steps.size());
+			// Shared per-invocation cache so multiple steps declared in the same class only resolve
+			// that class's IType once, if/when their lazy resolution actually runs.
 			Map<String, IType> typeBuffer = new ConcurrentHashMap<>();
-			LongAdder getMethodsNanos = new LongAdder();
-			LongAdder filterNanos = new LongAdder();
-			LongAdder lineNumberNanos = new LongAdder();
 			Collection<StepDefinition> result = steps.parallelStream()
-					.map(cucumberStep -> parseStepDefintion(cucumberStep, javaProject, typeBuffer, perf,
-							getMethodsNanos, filterNanos, lineNumberNanos, remaining.split(1)))
-					.filter(Objects::nonNull).collect(Collectors.toList());
+					.map(cucumberStep -> parseStepDefintion(cucumberStep, javaProject, typeBuffer))
+					.collect(Collectors.toList());
 
 			if (perf) {
-				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "findStepDefinitions: resolved "
+				Tracing.get().trace(Tracing.PERFORMANCE_STEPS, "findStepDefinitions: built "
 						+ result.size() + "/" + steps.size() + " in " + (System.currentTimeMillis() - start) + "ms");
-				Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
-						"findStepDefinitions phase breakdown (summed across all step def(s), threads run in parallel"
-								+ " so this can exceed wall time): getMethods=" + toMs(getMethodsNanos)
-								+ "ms, resolveTypeMethod=" + toMs(filterNanos) + "ms, lineNumber="
-								+ toMs(lineNumberNanos)
-								+ "ms; javadoc is now computed lazily on first getDescription() call - see"
-								+ " JavaGlueModelCache's own trace line for its render/cache-hit timing");
 			}
 			return result;
 		} catch (OperationCanceledException e) {
@@ -98,59 +88,132 @@ public class CucumberStepDefinitionProvider extends JavaStepDefinitionsProvider 
 	}
 
 	private StepDefinition parseStepDefintion(CucumberStepDefinition cucumberStep, IJavaProject project,
-			Map<String, IType> typeBuffer, boolean perf, LongAdder getMethodsNanos, LongAdder filterNanos,
-			LongAdder lineNumberNanos, IProgressMonitor monitor) {
+			Map<String, IType> typeBuffer) {
 		CucumberCodeLocation codeLocation = cucumberStep.getCodeLocation();
 		io.cucumber.plugin.event.StepDefinition cucumberStepDefinition = cucumberStep.getStepDefinition();
-		IType type = typeBuffer.computeIfAbsent(codeLocation.getTypeName(), typeName -> {
-			try {
-				return project.findType(typeName, monitor);
-			} catch (JavaModelException e) {
-				return null;
-			}
-		});
-		if (type != null) {
-			try {
-				long t0 = perf ? System.nanoTime() : 0;
-				IMethod[] typeMethods = modelCache.getMethods(type);
-				if (perf) {
-					getMethodsNanos.add(System.nanoTime() - t0);
-				}
-				long t1 = perf ? System.nanoTime() : 0;
-				IMethod[] methods = modelCache.resolveTypeMethod(typeMethods, codeLocation);
-				if (perf) {
-					filterNanos.add(System.nanoTime() - t1);
-				}
-				if (methods.length == 1) {
-					// perfect match
-					IMethod method = methods[0];
-					long t2 = perf ? System.nanoTime() : 0;
-					int lineNumber = modelCache.getLineNumber(method.getCompilationUnit(), method);
-					if (perf) {
-						lineNumberNanos.add(System.nanoTime() - t2);
-					}
-					ExpressionDefinition expression = new ExpressionDefinition(cucumberStepDefinition.getPattern());
-					String id = method.getHandleIdentifier();
-					return new StepDefinition(id, JDTUtil.getMethodName(method), expression, type.getResource(),
-							lineNumber, method.getElementName(), type.getPackageFragment().getElementName(),
-							() -> {
-								try {
-									return getParameter(method);
-								} catch (JavaModelException e) {
-									return new StepParameter[0];
-								}
-							}, () -> modelCache.getJavadoc(method));
-				}
-			} catch (JavaModelException e) {
-			}
-		}
-		return new StepDefinition(cucumberStepDefinition.getLocation(), StepDefinition.NO_LABEL,
-				new ExpressionDefinition(cucumberStepDefinition.getPattern()), null, -1,
-				cucumberStepDefinition.getLocation(), "", null, (String) null);
+		String location = cucumberStepDefinition.getLocation();
+		ExpressionDefinition expression = new ExpressionDefinition(cucumberStepDefinition.getPattern());
+		LazyStepMethod lazyMethod = new LazyStepMethod(modelCache, project, typeBuffer, codeLocation);
+		return new StepDefinition(location, buildLabel(codeLocation), expression,
+				() -> resolveLocation(lazyMethod.resolve()), () -> resolveParameters(lazyMethod.resolve()),
+				() -> resolveJavadoc(lazyMethod.resolve()));
 	}
 
-	private static long toMs(LongAdder nanos) {
-		return nanos.sum() / 1_000_000;
+	/**
+	 * Builds a step's label directly from Cucumber's own reported code location - the same
+	 * information {@link JDTUtil#getMethodName(IMethod)} would produce from a resolved method, but
+	 * without needing to resolve anything via JDT first.
+	 */
+	private static String buildLabel(CucumberCodeLocation codeLocation) {
+		String typeName = codeLocation.getTypeName();
+		int lastDot = typeName.lastIndexOf('.');
+		String simpleName = lastDot >= 0 ? typeName.substring(lastDot + 1) : typeName;
+		return simpleName + "." + codeLocation.getMethodName() + "(" + String.join(",", codeLocation.getParameter())
+				+ ")";
+	}
+
+	private ResolvedLocation resolveLocation(IMethod method) {
+		if (method == null) {
+			return ResolvedLocation.NONE;
+		}
+		try {
+			IType type = method.getDeclaringType();
+			int lineNumber = modelCache.getLineNumber(method.getCompilationUnit(), method);
+			return new ResolvedLocation(type.getResource(), lineNumber, method.getElementName(),
+					type.getPackageFragment().getElementName());
+		} catch (JavaModelException e) {
+			return ResolvedLocation.NONE;
+		}
+	}
+
+	private StepParameter[] resolveParameters(IMethod method) {
+		if (method == null) {
+			return new StepParameter[0];
+		}
+		try {
+			return getParameter(method);
+		} catch (JavaModelException e) {
+			return new StepParameter[0];
+		}
+	}
+
+	private String resolveJavadoc(IMethod method) {
+		return method == null ? null : modelCache.getJavadoc(method);
+	}
+
+	/**
+	 * Lazily resolves the {@link IMethod} backing a step definition - the actual expensive JDT work
+	 * (find the declaring type, fetch its methods, disambiguate overloads) is deferred until
+	 * {@link #resolve()} is first called, and memoized from then on, so it happens at most once per
+	 * step regardless of how many of {@link StepDefinition}'s lazy accessors end up needing it.
+	 */
+	private static final class LazyStepMethod {
+
+		private final JavaGlueModelCache modelCache;
+		private final IJavaProject project;
+		private final Map<String, IType> typeBuffer;
+		private final CucumberCodeLocation codeLocation;
+
+		private volatile IMethod method;
+		private volatile boolean resolved;
+
+		LazyStepMethod(JavaGlueModelCache modelCache, IJavaProject project, Map<String, IType> typeBuffer,
+				CucumberCodeLocation codeLocation) {
+			this.modelCache = modelCache;
+			this.project = project;
+			this.typeBuffer = typeBuffer;
+			this.codeLocation = codeLocation;
+		}
+
+		IMethod resolve() {
+			if (!resolved) {
+				synchronized (this) {
+					if (!resolved) {
+						long start = Tracing.PERF_STEPS ? System.nanoTime() : 0;
+						try {
+							method = doResolve();
+						} catch (RuntimeException e) {
+							// resolution can now run long after findStepDefinitions returned (e.g. on
+							// template insertion or hover) - the project/type/method may no longer be
+							// in the state it was when this step was first listed, so fail open rather
+							// than propagate into StepDefinition's lazy accessors.
+							method = null;
+						}
+						if (Tracing.PERF_STEPS) {
+							Tracing.get().trace(Tracing.PERFORMANCE_STEPS,
+									"LazyStepMethod.resolve(): resolved '" + codeLocation + "' to "
+											+ (method != null ? method.getHandleIdentifier() : "<no match>") + " in "
+											+ ((System.nanoTime() - start) / 1_000_000) + "ms");
+						}
+						resolved = true;
+					}
+				}
+			}
+			return method;
+		}
+
+		private IMethod doResolve() {
+			IType type = typeBuffer.computeIfAbsent(codeLocation.getTypeName(), typeName -> {
+				try {
+					return project.findType(typeName, (IProgressMonitor) null);
+				} catch (JavaModelException e) {
+					return null;
+				}
+			});
+			if (type == null) {
+				return null;
+			}
+			try {
+				IMethod[] typeMethods = modelCache.getMethods(type);
+				IMethod[] methods = modelCache.resolveTypeMethod(typeMethods, codeLocation);
+				if (methods != null && methods.length == 1) {
+					return methods[0];
+				}
+			} catch (JavaModelException e) {
+			}
+			return null;
+		}
+
 	}
 
 }


### PR DESCRIPTION
Traced every consumer of a built StepDefinition and found that even after the getMethods/ getParameterNames/getLineNumber/getJavadoc caching already in place, and after deferring StepParameter/Javadoc computation until a proposal is actually inspected or inserted, CucumberStepDefinitionProvider.parseStepDefintion still resolved an IType/IMethod for every one of 414 candidates on every content-assist invocation, unconditionally - for a result that only fed the proposal's label. CucumberCodeLocation (already parsed from Cucumber's own reported location string, before any JDT call) has the same type/method/parameter-type information as plain text - the same shape JDTUtil.getMethodName(method) reconstructs from a resolved handle.

Two changes:

1. CucumberStepDefinitionProvider builds the label directly from CucumberCodeLocation (type/method/ parameter-type strings, trimmed to a simple class name to match the existing display format) instead of a resolved IMethod - zero JDT calls, and it fixes a pre-existing display bug in JDTUtil.getMethodName along the way (that method computes a joined parameter-type string but never appends it, so parentheses were always empty; left JDTUtil.getMethodName itself unchanged since it still has an unrelated live caller in JavaReferencesCodeMiningProvider).

2. All JDT resolution (find the declaring type, fetch its methods via the persistent cache, disambiguate overloads) moves behind a new LazyStepMethod holder - a per-step, double-checked-locking memoized resolver, the same pattern already used for StepDefinition's description and parameters. Previously getParameters()/getDescription() were each independently lazy but their suppliers already closed over an eagerly-resolved IMethod; now the method resolution itself is the lazy step, with parameters/description/location all depending on its memoized result. Catches RuntimeException broadly around the resolution call (not just JavaModelException) since it can now run long after findStepDefinitions returned, on a different thread, when the project/type may no longer be in the state it was when the step was first listed - fails open (null method) rather than propagating into StepDefinition's lazy accessors.

StepDefinition.java (editor bundle) changes to support this:
- source/lineNumber/sourceName/packageName replaced by one shared, lazy ResolvedLocation holder (all four are derived from the same resolution, not independent).
- parseStepDefintion's matched/unmatched branching is gone - there's only one construction path now; a resolution failure just means the lazy accessors gracefully return the same defaults (NO_LINE_NUMBER/null/empty array) the old unmatched branch used to construct eagerly. Verified this does not affect the feature-file "unmatched step" warning markers - those come from the entirely separate JavaGlueJob.validateGlue() job (confirmed via grep: zero references to CucumberStepDefinitionProvider/findStepDefinitions in that class), and content-assist's own popup doesn't visually distinguish matched/unmatched today either (a single static icon for every proposal).
- equals()/hashCode() no longer reference lineNumber/source/sourceName/packageName - referencing them would force the very resolution being deferred just by putting a StepDefinition in a HashSet/Map. Narrowed to id/label/expression, which are all cheap and eager under the new design and were already the primary identity fields in practice.
- The old getMethods/resolveTypeMethod/lineNumber phase-breakdown tracing is removed - it measured work that mostly no longer happens inside findStepDefinitions at all. Real signal moves to LazyStepMethod's own trace line, reporting what a step resolved to (or "<no match>") and how long it took, if and when it actually runs.

StorageHelper.readStepDefinition updated to match the new constructor signature (wraps its already-known values in a trivial supplier - no laziness benefit needed there, just matching the new shape). writeStepDefinition unchanged - it already goes through the public getters.

Verified with a live trace capture: findStepDefinitions now completes in 0-7ms regardless of cache state (previously up to ~17s cold), the first touch of a not-yet-resolved class correctly pays its real JDT cost exactly once and only when a proposal is actually inspected or inserted, repeat access to the same proposal is fully cached, "go to definition" (a separate, independent code path) is unaffected and continues to work, and the feature-file warning-marker job is unaffected and continues to report matches/misses exactly as before.
