### PR TITLE
Use Temurin with setup-java v6

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
         architecture: 'x64'
     - name: Build with Maven
       working-directory: code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
         architecture: 'x64'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
## Summary

- replace the removed `adopt` distribution with `temurin` in both workflows upgraded to setup-java v6
- preserve Java 21, x64, caching, and the pinned setup-java v6 commit from Renovate

## Why

This is a companion repair for #705. setup-java v6 deliberately removed the legacy `adopt` input and documents `temurin` as the HotSpot migration target. The current bot head therefore stops before the Maven build with `No supported distribution was found for input adopt`.

## Verification

- `mvn -B -ntp clean verify` with JDK 21 — **BUILD SUCCESS** across all 9 reactor modules
- parsed all three repository workflow YAML files successfully
- `git diff --check`

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
