### PR TITLE
Use Temurin for setup-java

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
         architecture: 'x64'
     - name: Build with Maven
       working-directory: code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
         architecture: 'x64'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
## Summary

- replace the deprecated `adopt` distribution with `temurin` in the test and deploy workflows
- preserve Java 21, x64, Maven caching, and the pinned setup-java action version

## Context

This follows the maintainer request on #707 to apply the repair as an independent commit against `main`, where Renovate cannot overwrite it. setup-java v5 deprecates `adopt` in favor of `temurin`, and setup-java v6 removes the legacy alias. Once this lands, Renovate can rebase #705 onto the durable fix.

## Verification

- `mvn -B -ntp clean verify` with JDK 21 — **BUILD SUCCESS** across all 9 reactor modules
- parsed all 3 repository workflow YAML files
- `git diff --check`

## AI assistance

- JAIPilot skills used: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- JAIPilot: https://github.com/JAIPilot/jaipilot
- Host model identifier: not exposed by host
- Reasoning effort: not exposed by host
- Execution/service mode: local execution; JAIPilot Remote was not used
